### PR TITLE
Plugin fixes

### DIFF
--- a/example-plugin/src/lib.rs
+++ b/example-plugin/src/lib.rs
@@ -1,6 +1,6 @@
 mod example_protocol;
 
-use example_protocol::*;
+use example_protocol::prelude::*;
 use std::collections::{BTreeMap, HashMap};
 use std::panic;
 

--- a/example-protocol/src/assets/rust_plugin_test/expected_mod.rs
+++ b/example-protocol/src/assets/rust_plugin_test/expected_mod.rs
@@ -1,16 +1,21 @@
 mod r#async;
-mod functions;
+pub mod functions;
 mod queue;
 mod support;
 mod task;
-mod types;
+pub mod types;
 
-pub use functions::*;
-pub use r#async::{AsyncValue as _FP_AsyncValue, __fp_guest_resolve_async_value};
-pub use support::{
-    FatPtr as _FP_FatPtr, __fp_free, __fp_malloc, export_value_to_host as _fp_export_value_to_host,
-    from_fat_ptr as _fp_from_fat_ptr, import_value_from_host as _fp_import_value_from_host,
-    malloc as _fp_malloc, to_fat_ptr as _fp_to_fat_ptr,
-};
-pub use task::Task as _FP_Task;
-pub use types::*;
+pub mod __fp_macro {
+    pub use super::r#async::{AsyncValue, __fp_guest_resolve_async_value};
+    pub use super::support::{
+        FatPtr, __fp_free, __fp_malloc, export_value_to_host, from_fat_ptr, import_value_from_host,
+        malloc, to_fat_ptr,
+    };
+    pub use super::task::Task;
+}
+
+pub mod prelude {
+    pub use super::__fp_macro;
+    pub use super::functions::*;
+    pub use super::types::*;
+}

--- a/fp-bindgen/src/generators/rust_plugin/assets/task.rs
+++ b/fp-bindgen/src/generators/rust_plugin/assets/task.rs
@@ -26,7 +26,7 @@ pub struct Task {
 }
 
 impl Task {
-    pub(crate) fn spawn(future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
+    pub fn spawn(future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
         let this = Rc::new(Self {
             inner: RefCell::new(None),
             is_queued: Cell::new(false),


### PR DESCRIPTION
Some various visibility fixes that prevented plugins from being built against the generated bindings when crossing crate boundaries.

Also introduced a prelude, because the prefixed functions were getting too much for me :sweat_smile: 