### PR TITLE
Cache type dependencies

### DIFF
--- a/fp-bindgen/src/types/mod.rs
+++ b/fp-bindgen/src/types/mod.rs
@@ -1,6 +1,4 @@
 use crate::primitives::Primitive;
-use dashmap::DashMap;
-use once_cell::sync::Lazy;
 use quote::ToTokens;
 use std::{
     collections::{hash_map::DefaultHasher, BTreeSet},
@@ -53,25 +51,15 @@ pub enum Type {
 
 impl Type {
     pub fn from_item(item_str: &str, dependencies: &BTreeSet<Type>) -> Self {
-        static CACHE: Lazy<DashMap<String, Type>> = Lazy::new(DashMap::new);
-
-        if let Some(ty) = CACHE.get(item_str) {
-            return ty.clone();
-        }
-
         let item = syn::parse_str::<Item>(item_str).unwrap();
-        let ty = match item {
+        match item {
             Item::Enum(item) => enums::parse_enum_item(item, dependencies),
             Item::Struct(item) => structs::parse_struct_item(item, dependencies),
             item => panic!(
                 "Only struct and enum types can be constructed from an item. Found: {:?}",
                 item
             ),
-        };
-
-        CACHE.insert(item_str.to_owned(), ty.clone());
-
-        ty
+        }
     }
 
     pub fn generic_args(&self) -> Vec<GenericArgument> {

--- a/macros/src/primitives.rs
+++ b/macros/src/primitives.rs
@@ -38,7 +38,7 @@ impl Primitive {
                     true
                 }
 
-                fn dependencies() -> BTreeSet<Type> {
+                fn build_dependencies() -> BTreeSet<Type> {
                     BTreeSet::new()
                 }
             }

--- a/macros/src/serializable.rs
+++ b/macros/src/serializable.rs
@@ -92,7 +92,7 @@ pub(crate) fn impl_derive_serializable(item: TokenStream) -> TokenStream {
                 fp_bindgen::prelude::Type::from_item(#item_str, &Self::dependencies())
             }
 
-            fn dependencies() -> std::collections::BTreeSet<fp_bindgen::prelude::Type> {
+            fn build_dependencies() -> std::collections::BTreeSet<fp_bindgen::prelude::Type> {
                 let generics = #generics_str;
                 #collect_dependencies
             }


### PR DESCRIPTION
On my machine, generating the bindings for FiberKit went down from 6m16s to <3s. I'd call that a win.

I've removed the cache inside `from_item()` because it's effect is now within the margin of error.