### PR TITLE
FP-798: Don't re-export from macros crate

### DIFF
--- a/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
+++ b/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 fp-bindgen-support = { path = "../../fp-bindgen-support", features = ["async"] }
-fp-bindgen-macros = { path = "../../macros" }
 chrono = { version = "0.4.19", features = ["serde"] }
 once_cell = "1"
 rmp-serde = "=1.0.0-beta.2"

--- a/example-protocol/src/assets/rust_plugin_test/expected_lib.rs
+++ b/example-protocol/src/assets/rust_plugin_test/expected_lib.rs
@@ -1,4 +1,6 @@
+#[rustfmt::skip]
 mod export;
+#[rustfmt::skip]
 mod import;
 #[rustfmt::skip]
 mod types;
@@ -7,5 +9,4 @@ pub use export::*;
 pub use import::*;
 pub use types::*;
 
-pub use fp_bindgen_macros::fp_export_impl;
 pub use fp_bindgen_support::*;

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -40,7 +40,6 @@ edition = \"2018\"
 
 [dependencies]
 fp-bindgen-support = {{ path = \"../../fp-bindgen-support\"{} }}
-fp-bindgen-macros = {{ path = \"../../macros\" }}
 chrono = {{ version = \"0.4.19\", features = [\"serde\"] }}
 once_cell = \"1\"
 rmp-serde = \"=1.0.0-beta.2\"
@@ -60,7 +59,9 @@ serde_bytes = \"0.11\"
 
     write_bindings_file(
         format!("{}/lib.rs", src_path),
-        "mod export;
+        "#[rustfmt::skip]
+mod export;
+#[rustfmt::skip]
 mod import;
 #[rustfmt::skip]
 mod types;
@@ -69,7 +70,6 @@ pub use export::*;
 pub use import::*;
 pub use types::*;
 
-pub use fp_bindgen_macros::fp_export_impl;
 pub use fp_bindgen_support::*;
 ",
     );


### PR DESCRIPTION
Also added a few `rustfmt::skip` annotations for generated files.