### PR TITLE
Fix feature config

### DIFF
--- a/fp-bindgen/src/serializable.rs
+++ b/fp-bindgen/src/serializable.rs
@@ -1,7 +1,7 @@
 use dashmap::{mapref::one::Ref, DashMap};
 use once_cell::sync::Lazy;
 
-#[cfg(feature = "chrono-compat")]
+#[cfg(any(feature = "chrono-compat", feature = "serde-bytes-compat"))]
 use crate::CustomType;
 use crate::{
     generics::{contains_generic_arg, specialize_type_with_dependencies},


### PR DESCRIPTION
Without this fix, enabling `serde-bytes-compat` would result in an error if `chrono-compat` was not also enabled.