### PR TITLE
Handle struct field attributes

### DIFF
--- a/example-protocol/src/assets/rust_plugin_test/expected_types.rs
+++ b/example-protocol/src/assets/rust_plugin_test/expected_types.rs
@@ -25,6 +25,11 @@ pub struct ComplexHostToGuest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub complex_nested: Option<BTreeMap<String, Vec<Point<f64>>>>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    #[serde(rename = "optional_timestamp", skip_serializing_if = "Option::is_none")]
+    pub renamed: Option<chrono::DateTime<chrono::Utc>>,
+
+    /// Raw identifiers are supported too.
+    pub r#type: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
+++ b/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
@@ -29,6 +29,11 @@ pub struct ComplexHostToGuest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub complex_nested: Option<BTreeMap<String, Vec<Point<f64>>>>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    #[serde(rename = "optional_timestamp", skip_serializing_if = "Option::is_none")]
+    pub renamed: Option<chrono::DateTime<chrono::Utc>>,
+
+    /// Raw identifiers are supported too.
+    pub r#type: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/example-protocol/src/assets/ts_runtime_test/expected_types.ts
+++ b/example-protocol/src/assets/ts_runtime_test/expected_types.ts
@@ -25,6 +25,12 @@ export type ComplexHostToGuest = {
     recursive: Array<Point<Point<number>>>;
     complexNested?: Record<string, Array<Point<number>>>;
     timestamp: string;
+    optional_timestamp?: string;
+
+    /**
+     * Raw identifiers are supported too.
+     */
+    type: string;
 };
 
 export type ExplicitedlyImportedType = {

--- a/example-protocol/src/main.rs
+++ b/example-protocol/src/main.rs
@@ -32,6 +32,10 @@ pub struct ComplexHostToGuest {
     pub recursive: Vec<Point<Point<f64>>>,
     pub complex_nested: Option<BTreeMap<String, Vec<Point<f64>>>>,
     pub timestamp: DateTime<Utc>,
+    #[fp(rename = "optional_timestamp")]
+    pub renamed: Option<DateTime<Utc>>,
+    /// Raw identifiers are supported too.
+    pub r#type: String,
 }
 
 pub type ComplexAlias = ComplexGuestToHost;

--- a/fp-bindgen/src/generators/ts_runtime/mod.rs
+++ b/fp-bindgen/src/generators/ts_runtime/mod.rs
@@ -809,14 +809,14 @@ fn format_struct_fields(fields: &[Field]) -> Vec<String> {
                     let optional = if name == "Option" { "?" } else { "" };
                     format!(
                         "{}{}: {};",
-                        field.name.to_camel_case(),
+                        get_field_name(field),
                         optional,
                         format_type_with_options(ty, format_opts)
                     )
                 }
                 ty => format!(
                     "{}: {};",
-                    field.name.to_camel_case(),
+                    get_field_name(field),
                     format_type_with_options(ty, format_opts)
                 ),
             };
@@ -842,6 +842,16 @@ fn format_raw_type(ty: &Type) -> String {
         Type::Primitive(primitive) => format_primitive(*primitive),
         Type::Unit => "void".to_owned(),
         _ => "Uint8Array".to_owned(),
+    }
+}
+
+fn get_field_name(field: &Field) -> String {
+    if let Some(rename) = field.attrs.rename.as_ref() {
+        rename.to_owned()
+    } else if field.name.starts_with("r#") {
+        field.name[2..].to_camel_case()
+    } else {
+        field.name.to_camel_case()
     }
 }
 

--- a/fp-bindgen/src/generics.rs
+++ b/fp-bindgen/src/generics.rs
@@ -30,6 +30,7 @@ use syn::{AngleBracketedGenericArguments, Path, PathArguments};
 ///             ty: None
 ///         })),
 ///         doc_lines: vec![],
+///         attrs: FieldAttrs::default(),
 ///     }],
 ///     StructOptions::default(),
 /// );

--- a/fp-bindgen/src/serializable.rs
+++ b/fp-bindgen/src/serializable.rs
@@ -394,7 +394,7 @@ mod tests {
     use crate::{
         casing::Casing,
         primitives::Primitive,
-        types::{Field, GenericArgument, StructOptions},
+        types::{Field, FieldAttrs, GenericArgument, StructOptions},
         Type,
     };
     use pretty_assertions::assert_eq;
@@ -477,6 +477,7 @@ mod tests {
                     name: "T".to_owned(),
                     ty: Some(Type::Primitive(Primitive::F64)),
                 })),
+                attrs: FieldAttrs::default(),
             }],
             StructOptions {
                 field_casing: Casing::CamelCase,
@@ -533,6 +534,7 @@ mod tests {
                     name: "T".to_owned(),
                     ty: None,
                 })),
+                attrs: FieldAttrs::default(),
             }],
             StructOptions {
                 field_casing: Casing::CamelCase,
@@ -613,6 +615,7 @@ mod tests {
                     name: "T".to_owned(),
                     ty: None,
                 })),
+                attrs: FieldAttrs::default(),
             }],
             StructOptions {
                 field_casing: Casing::CamelCase,
@@ -676,6 +679,7 @@ mod tests {
                     name: "T".to_owned(),
                     ty: None,
                 })),
+                attrs: FieldAttrs::default(),
             }],
             StructOptions {
                 field_casing: Casing::CamelCase,
@@ -756,6 +760,7 @@ mod tests {
                     name: "T".to_owned(),
                     ty: None,
                 })),
+                attrs: FieldAttrs::default(),
             }],
             StructOptions {
                 field_casing: Casing::CamelCase,

--- a/fp-bindgen/src/types/mod.rs
+++ b/fp-bindgen/src/types/mod.rs
@@ -11,7 +11,7 @@ mod enums;
 mod structs;
 
 pub use enums::{EnumOptions, Variant};
-pub use structs::{Field, StructOptions};
+pub use structs::{Field, FieldAttrs, StructOptions};
 
 /// A generic argument has a name (T, E, ...) and an optional type, which is only known in contexts
 /// when we are dealing with concrete instances of the generic type.
@@ -157,6 +157,7 @@ impl Type {
                         doc_lines: field.doc_lines,
                         name: field.name,
                         ty: field.ty.with_specialized_args(specialized_args),
+                        attrs: field.attrs,
                     })
                     .collect(),
                 opts,

--- a/fp-bindgen/src/types/structs.rs
+++ b/fp-bindgen/src/types/structs.rs
@@ -36,10 +36,12 @@ pub(crate) fn parse_struct_item(item: ItemStruct, dependencies: &BTreeSet<Type>)
                 .to_string();
             let ty = resolve_type_or_panic(&field.ty, dependencies, "Unresolvable field type");
             let doc_lines = get_doc_lines(&field.attrs);
+            let attrs = FieldAttrs::from_attrs(&field.attrs);
             Field {
                 name,
                 ty,
                 doc_lines,
+                attrs,
             }
         })
         .collect();
@@ -89,7 +91,7 @@ impl StructOptions {
         opts
     }
 
-    fn merge_with(&mut self, other: &StructOptions) {
+    fn merge_with(&mut self, other: &Self) {
         if other.field_casing != Casing::default() {
             self.field_casing = other.field_casing;
         }
@@ -112,32 +114,28 @@ impl Parse for StructOptions {
         let content;
         parenthesized!(content in input);
 
+        let parse_value = || -> Result<String> {
+            content.parse::<Token![=]>()?;
+            Ok(content
+                .parse::<LitStr>()?
+                .to_token_stream()
+                .to_string()
+                .trim_matches('"')
+                .to_owned())
+        };
+
         let mut result = Self::default();
         loop {
             let key: Ident = content.call(IdentExt::parse_any)?;
-            match &*key.to_string() {
+            match key.to_string().as_ref() {
                 "rename_all" => {
-                    content.parse::<Token![=]>()?;
-                    result.field_casing = Casing::try_from(
-                        content
-                            .parse::<LitStr>()?
-                            .to_token_stream()
-                            .to_string()
-                            .trim_matches('"'),
-                    )
-                    .map_err(|err| Error::new(content.span(), err))?;
+                    result.field_casing = Casing::try_from(parse_value()?.as_ref())
+                        .map_err(|err| Error::new(content.span(), err))?
                 }
                 module if module.ends_with("_module") => {
-                    content.parse::<Token![=]>()?;
-                    let value = content
-                        .parse::<LitStr>()?
-                        .to_token_stream()
-                        .to_string()
-                        .trim_matches('"')
-                        .to_owned();
                     result
                         .native_modules
-                        .insert(module[0..module.len() - 7].to_owned(), value);
+                        .insert(module[0..module.len() - 7].to_owned(), parse_value()?);
                 }
                 other => {
                     return Err(Error::new(
@@ -163,4 +161,129 @@ pub struct Field {
     pub name: String,
     pub ty: Type,
     pub doc_lines: Vec<String>,
+    pub attrs: FieldAttrs,
+}
+
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct FieldAttrs {
+    /// Optional Serde dependency used for deserialization.
+    pub deserialize_with: Option<String>,
+
+    /// Optional name to use in the serialized format
+    /// (only used if different than the field name itself).
+    pub rename: Option<String>,
+
+    /// Optional Serde dependency used for serialization.
+    pub serialize_with: Option<String>,
+
+    /// Optional condition for skipping serialization of the field.
+    /// Mainly used for omitting `Option`s.
+    pub skip_serializing_if: Option<String>,
+}
+
+impl FieldAttrs {
+    pub fn from_attrs(attrs: &[Attribute]) -> Self {
+        let mut opts = Self::default();
+        for attr in attrs {
+            if attr.path.is_ident("fp") || attr.path.is_ident("serde") {
+                opts.merge_with(
+                    &syn::parse2::<Self>(attr.tokens.clone())
+                        .expect("Could not parse field attributes"),
+                );
+            }
+        }
+        opts
+    }
+
+    fn merge_with(&mut self, other: &Self) {
+        if other.deserialize_with.is_some() {
+            self.deserialize_with = other.deserialize_with.clone();
+        }
+        if other.rename.is_some() {
+            self.rename = other.rename.clone();
+        }
+        if other.serialize_with.is_some() {
+            self.serialize_with = other.serialize_with.clone();
+        }
+        if other.skip_serializing_if.is_some() {
+            self.skip_serializing_if = other.skip_serializing_if.clone();
+        }
+    }
+
+    pub fn to_serde_attrs(&self) -> Vec<String> {
+        let mut serde_attrs = vec![];
+        match (self.deserialize_with.as_ref(), self.serialize_with.as_ref()) {
+            (Some(deserialize_with), Some(serialize_with))
+                if deserialize_with == serialize_with =>
+            {
+                serde_attrs.push(format!("with = \"{}\"", deserialize_with));
+            }
+            (Some(deserialize_with), Some(serialize_with)) => {
+                serde_attrs.push(format!("deserialize_with = \"{}\"", deserialize_with));
+                serde_attrs.push(format!("serialize_with = \"{}\"", serialize_with));
+            }
+            (Some(deserialize_with), None) => {
+                serde_attrs.push(format!("deserialize_with = \"{}\"", deserialize_with));
+            }
+            (None, Some(serialize_with)) => {
+                serde_attrs.push(format!("serialize_with = \"{}\"", serialize_with));
+            }
+            (None, None) => {}
+        }
+        if let Some(rename) = self.rename.as_ref() {
+            serde_attrs.push(format!("rename = \"{}\"", rename));
+        }
+        if let Some(skip_serializing_if) = self.skip_serializing_if.as_ref() {
+            serde_attrs.push(format!("skip_serializing_if = \"{}\"", skip_serializing_if));
+        }
+        serde_attrs.sort();
+        serde_attrs
+    }
+}
+
+impl Parse for FieldAttrs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        parenthesized!(content in input);
+
+        let parse_value = || -> Result<String> {
+            content.parse::<Token![=]>()?;
+            Ok(content
+                .parse::<LitStr>()?
+                .to_token_stream()
+                .to_string()
+                .trim_matches('"')
+                .to_owned())
+        };
+
+        let mut result = Self::default();
+        loop {
+            let key: Ident = content.call(IdentExt::parse_any)?;
+            match key.to_string().as_ref() {
+                "deserialize_with" => result.deserialize_with = Some(parse_value()?),
+                "rename" => result.rename = Some(parse_value()?),
+                "serialize_with" => result.serialize_with = Some(parse_value()?),
+                "skip_serializing_if" => result.skip_serializing_if = Some(parse_value()?),
+                "with" => {
+                    let value = parse_value()?;
+                    result.deserialize_with = Some(value.clone());
+                    result.serialize_with = Some(value);
+                }
+                other => {
+                    return Err(Error::new(
+                        content.span(),
+                        format!("Unexpected field attribute: {}", other),
+                    ))
+                }
+            }
+
+            if content.is_empty() {
+                break;
+            }
+
+            content.parse::<Token![,]>()?;
+        }
+
+        Ok(result)
+    }
 }


### PR DESCRIPTION
I ran into a situation where I needed to handle a struct field called `type`, but this caused some issues with `fp-bindgen`:

* Calling it `r#type` almost worked, but caused an issue in the TS generator, where the property would be named `rType` instead.
* We didn't support attributes for struct fields at all, so using `#[serde(rename = "type")]` was also out of the question.

With this PR, both of these options are supported, and we gain more generic handling for field attributes in general.