### PR TITLE
Implemented fp_export_host_impl proc_macro.

### DIFF
--- a/example-plugin/Cargo.lock
+++ b/example-plugin/Cargo.lock
@@ -33,7 +33,6 @@ name = "example-bindings"
 version = "1.0.0"
 dependencies = [
  "chrono",
- "fp-bindgen-macros",
  "fp-bindgen-support",
  "once_cell",
  "rmp-serde",
@@ -157,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ad345f2f82b7ac54d949ce2508f49401d0fe7bb6085b5da20c7c0ad013dfa2"
+checksum = "05d18f64792a930cdb215b849eb75d8d7ffaaf70c3b9bd594b5ccc5ab63b4f70"
 dependencies = [
  "byteorder",
  "rmp",

--- a/example-plugin/src/lib.rs
+++ b/example-plugin/src/lib.rs
@@ -1,4 +1,5 @@
-use example_bindings::*;
+use chrono::Utc;
+use example_bindings::{import::*, *};
 use std::collections::{BTreeMap, HashMap};
 use std::panic;
 use time::OffsetDateTime;
@@ -11,14 +12,14 @@ fn init_panic_hook() {
     });
 }
 
-#[fp_export_impl(example_bindings)]
+#[fp_export_guest_impl(example_bindings)]
 fn my_plain_exported_function(a: u32, b: u32) -> u32 {
     init_panic_hook();
 
     a + my_plain_imported_function(a, b)
 }
 
-#[fp_export_impl(example_bindings)]
+#[fp_export_guest_impl(example_bindings)]
 fn my_complex_exported_function(a: ComplexHostToGuest) -> ComplexGuestToHost {
     init_panic_hook();
 
@@ -40,7 +41,7 @@ fn my_complex_exported_function(a: ComplexHostToGuest) -> ComplexGuestToHost {
     }
 }
 
-#[fp_export_impl(example_bindings)]
+#[fp_export_guest_impl(example_bindings)]
 async fn my_async_exported_function() -> ComplexGuestToHost {
     init_panic_hook();
 
@@ -52,7 +53,7 @@ async fn my_async_exported_function() -> ComplexGuestToHost {
     }
 }
 
-#[fp_export_impl(example_bindings)]
+#[fp_export_guest_impl(example_bindings)]
 async fn fetch_data(url: String) -> String {
     init_panic_hook();
 

--- a/example-protocol/src/assets/rust_plugin_test/expected_lib.rs
+++ b/example-protocol/src/assets/rust_plugin_test/expected_lib.rs
@@ -1,12 +1,10 @@
 #[rustfmt::skip]
-mod export;
+pub mod export;
 #[rustfmt::skip]
-mod import;
+pub mod import;
 #[rustfmt::skip]
 mod types;
 
-pub use export::*;
-pub use import::*;
 pub use types::*;
 
 pub use fp_bindgen_support::*;

--- a/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -1,8 +1,8 @@
-use super::types::*;
+use fp_provider::*;
 use crate::errors::InvocationError;
 use crate::{
     support::{
-        create_future_value, export_to_guest, export_to_guest_raw, import_from_guest,
+        create_future_value, export_value_to_guest, export_to_guest_raw, import_value_from_guest,
         resolve_async_value, FatPtr, ModuleRawFuture,
     },
     Runtime, RuntimeInstanceData,
@@ -16,7 +16,7 @@ impl Runtime {
         let instance = Instance::new(&self.module, &import_object).unwrap();
         env.init_with_instance(&instance).unwrap();
 
-        let url = export_to_guest(&env, &url);
+        let url = export_value_to_guest(&env, &url);
 
         let function = instance
             .exports
@@ -60,7 +60,7 @@ impl Runtime {
         let instance = Instance::new(&self.module, &import_object).unwrap();
         env.init_with_instance(&instance).unwrap();
 
-        let a = export_to_guest(&env, &a);
+        let a = export_value_to_guest(&env, &a);
 
         let function = instance
             .exports
@@ -73,7 +73,7 @@ impl Runtime {
             _ => return Err(InvocationError::UnexpectedReturnType),
         };
 
-        Ok(import_from_guest(&env, ptr))
+        Ok(import_value_from_guest(&env, ptr))
     }
 
     pub fn my_plain_exported_function(&self, a: u32, b: u32) -> Result<u32, InvocationError> {
@@ -181,72 +181,12 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
     imports! {
         "fp" => {
             "__fp_host_resolve_async_value" => Function::new_native_with_env(store, env.clone(), resolve_async_value),
-            "__fp_gen_count_words" => Function::new_native_with_env(store, env.clone(), _count_words),
-            "__fp_gen_log" => Function::new_native_with_env(store, env.clone(), _log),
-            "__fp_gen_make_request" => Function::new_native_with_env(store, env.clone(), _make_request),
-            "__fp_gen_my_async_imported_function" => Function::new_native_with_env(store, env.clone(), _my_async_imported_function),
-            "__fp_gen_my_complex_imported_function" => Function::new_native_with_env(store, env.clone(), _my_complex_imported_function),
-            "__fp_gen_my_plain_imported_function" => Function::new_native_with_env(store, env.clone(), _my_plain_imported_function),
+            "__fp_gen_count_words" => Function::new_native_with_env(store, env.clone(), super::__fp_gen_count_words),
+            "__fp_gen_log" => Function::new_native_with_env(store, env.clone(), super::__fp_gen_log),
+            "__fp_gen_make_request" => Function::new_native_with_env(store, env.clone(), super::__fp_gen_make_request),
+            "__fp_gen_my_async_imported_function" => Function::new_native_with_env(store, env.clone(), super::__fp_gen_my_async_imported_function),
+            "__fp_gen_my_complex_imported_function" => Function::new_native_with_env(store, env.clone(), super::__fp_gen_my_complex_imported_function),
+            "__fp_gen_my_plain_imported_function" => Function::new_native_with_env(store, env.clone(), super::__fp_gen_my_plain_imported_function),
         }
     }
-}
-
-pub fn _count_words(env: &RuntimeInstanceData, string: FatPtr) -> FatPtr {
-    let string = import_from_guest::<String>(env, string);
-
-    export_to_guest(env, &super::count_words(string))
-}
-
-pub fn _log(env: &RuntimeInstanceData, message: FatPtr) {
-    let message = import_from_guest::<String>(env, message);
-
-    super::log(message);
-}
-
-pub fn _make_request(env: &RuntimeInstanceData, opts: FatPtr) -> FatPtr {
-    let opts = import_from_guest::<RequestOptions>(env, opts);
-
-    let env = env.clone();
-    let async_ptr = create_future_value(&env);
-    let handle = tokio::runtime::Handle::current();
-    handle.spawn(async move {
-        let result_ptr = export_to_guest(&env, &super::make_request(opts).await);
-
-        unsafe {
-            env.__fp_guest_resolve_async_value
-                .get_unchecked()
-                .call(async_ptr, result_ptr)
-                .expect("Runtime error: Cannot resolve async value");
-        }
-    });
-
-    async_ptr
-}
-
-pub fn _my_async_imported_function(env: &RuntimeInstanceData) -> FatPtr {
-    let env = env.clone();
-    let async_ptr = create_future_value(&env);
-    let handle = tokio::runtime::Handle::current();
-    handle.spawn(async move {
-        let result_ptr = export_to_guest(&env, &super::my_async_imported_function().await);
-
-        unsafe {
-            env.__fp_guest_resolve_async_value
-                .get_unchecked()
-                .call(async_ptr, result_ptr)
-                .expect("Runtime error: Cannot resolve async value");
-        }
-    });
-
-    async_ptr
-}
-
-pub fn _my_complex_imported_function(env: &RuntimeInstanceData, a: FatPtr) -> FatPtr {
-    let a = import_from_guest::<ComplexAlias>(env, a);
-
-    export_to_guest(env, &super::my_complex_imported_function(a))
-}
-
-pub fn _my_plain_imported_function(env: &RuntimeInstanceData, a: u32, b: u32) -> u32 {
-    super::my_plain_imported_function(a, b)
 }

--- a/example-protocol/src/main.rs
+++ b/example-protocol/src/main.rs
@@ -172,6 +172,7 @@ fn main() {
         }),
         BindingsType::RustWasmerRuntime(WasmerRuntimeConfig {
             generate_raw_export_wrappers: true,
+            plugin_crate_name: "fp_provider",
         }),
         BindingsType::TsRuntime(TsRuntimeConfig {
             generate_raw_export_wrappers: true,
@@ -244,7 +245,8 @@ fn test_generate_rust_wasmer_runtime() {
     ];
     fp_bindgen!(BindingConfig {
         bindings_type: BindingsType::RustWasmerRuntime(WasmerRuntimeConfig {
-            generate_raw_export_wrappers: true
+            generate_raw_export_wrappers: true,
+            plugin_crate_name: "fp_provider",
         }),
         path: "bindings/rust-wasmer-runtime",
     });

--- a/fp-bindgen-support/src/lib.rs
+++ b/fp-bindgen-support/src/lib.rs
@@ -12,4 +12,6 @@ pub use r#async::*;
 #[cfg(feature = "async")]
 pub use task::Task;
 
-pub use fp_bindgen_macros::{fp_export_impl, fp_export_signature, fp_import_signature};
+pub use fp_bindgen_macros::{
+    fp_export_guest_impl, fp_export_host_impl, fp_export_signature, fp_import_signature,
+};

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -40,14 +40,12 @@ pub fn generate_bindings(
     write_bindings_file(
         format!("{}/lib.rs", src_path),
         "#[rustfmt::skip]
-mod export;
+pub mod export;
 #[rustfmt::skip]
-mod import;
+pub mod import;
 #[rustfmt::skip]
 mod types;
 
-pub use export::*;
-pub use import::*;
 pub use types::*;
 
 pub use fp_bindgen_support::*;

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/assets/support.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/assets/support.rs
@@ -40,7 +40,7 @@ pub(crate) struct AsyncValue {
 }
 
 /// Serialize an object from the linear memory and after that free up the memory
-pub(crate) fn import_from_guest<'de, T: Deserialize<'de>>(
+pub(crate) fn import_value_from_guest<'de, T: Deserialize<'de>>(
     env: &RuntimeInstanceData,
     fat_ptr: FatPtr,
 ) -> T {
@@ -84,7 +84,7 @@ pub(crate) fn import_from_guest_raw(env: &RuntimeInstanceData, fat_ptr: FatPtr) 
 }
 
 /// Serialize a value and put it in linear memory.
-pub(crate) fn export_to_guest<T: Serialize>(env: &RuntimeInstanceData, value: &T) -> FatPtr {
+pub(crate) fn export_value_to_guest<T: Serialize>(env: &RuntimeInstanceData, value: &T) -> FatPtr {
     let mut buffer = Vec::new();
     value.serialize(&mut Serializer::new(&mut buffer)).unwrap();
 

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -22,7 +22,7 @@ primitive_impls!();
 #[derive(Debug, Clone)]
 pub enum BindingsType<'a> {
     RustPlugin(RustPluginConfig<'a>),
-    RustWasmerRuntime(WasmerRuntimeConfig),
+    RustWasmerRuntime(WasmerRuntimeConfig<'a>),
     TsRuntime(TsRuntimeConfig),
 }
 
@@ -50,8 +50,9 @@ pub struct RustPluginConfig<'a> {
     pub dependencies: BTreeMap<String, String>,
 }
 #[derive(Debug, Clone)]
-pub struct WasmerRuntimeConfig {
+pub struct WasmerRuntimeConfig<'a> {
     pub generate_raw_export_wrappers: bool,
+    pub plugin_crate_name: &'a str,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This shuffles quite a few things around and replaces the previously generated wrapper functions with a proc macro similar to the provider solution.
It includes a small breaking change that `fp_export_impl` has been renamed to `fp_export_guest_impl` with a corresponding `fp_export_host_impl`.