### PR TITLE
Use the specific crates for the compilers

### DIFF
--- a/fp-bindgen/src/generators/rust_wasmer_runtime/assets/lib.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/assets/lib.rs
@@ -22,14 +22,14 @@ impl Runtime {
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer::Cranelift::default();
+        let compiler = wasmer_compiler_cranelift::Cranelift::default();
         let engine = Universal::new(compiler).engine();
         Store::new(&engine)
     }
 
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer::Singlepass::default();
+        let compiler = wasmer_compiler_singlepass::Singlepass::default();
         let engine = Universal::new(compiler).engine();
         Store::new(&engine)
     }


### PR DESCRIPTION
This allows us to get specific crates for specific architectures using cargo. Using features on a single crates did not work.