### PR TITLE
Revert "Refactor wasmer runtime generator to use quote! instead of format! (#53)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,12 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,7 +96,6 @@ dependencies = [
  "pretty_assertions 1.0.0",
  "proc-macro2",
  "quote",
- "rustfmt-wrapper",
  "serde_bytes",
  "syn",
  "time",
@@ -130,32 +123,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "home"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -209,21 +182,6 @@ checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "pretty_assertions"
@@ -292,55 +250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,15 +265,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rmp"
@@ -385,44 +285,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rustfmt-wrapper"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7733577fb5b13c8b256232e7ca84aa424f915efae6ec980082d60a03f99da3f8"
-dependencies = [
- "tempfile",
- "thiserror",
- "toolchain_find",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -466,40 +328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
-dependencies = [
- "cfg-if",
- "libc",
- "rand",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "time"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,25 +336,6 @@ dependencies = [
  "libc",
  "serde",
 ]
-
-[[package]]
-name = "toolchain_find"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e85654a10e7a07a47c6f19d93818f3f343e22927f2fa280c84f7c8042743413"
-dependencies = [
- "home",
- "lazy_static",
- "regex",
- "semver",
- "walkdir",
-]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"
@@ -539,23 +348,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"
@@ -572,15 +364,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -11,126 +11,207 @@ use wasmer::{imports, Function, ImportObject, Instance, Store, Value, WasmerEnv}
 
 impl Runtime {
     pub async fn fetch_data(&self, url: String) -> Result<String, InvocationError> {
-        let url = serialize_to_vec(url);
-        let res = self.fetch_data_raw(url);
-        let res = res.await?;
-        rmp_serde::from_slice(&res).unwrap()
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+
+        let url = export_to_guest(&env, &url);
+
+        let function = instance
+            .exports
+            .get_function("__fp_gen_fetch_data")
+            .map_err(|_| InvocationError::FunctionNotExported)?;
+        let result = function.call(&[url.into()])?;
+
+        let async_ptr: FatPtr = match result[0] {
+            Value::I64(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        };
+
+        let raw_result = ModuleRawFuture::new(env.clone(), async_ptr).await;
+        Ok(rmp_serde::from_slice(&raw_result).unwrap())
     }
+
+    pub async fn my_async_exported_function(&self) -> Result<ComplexGuestToHost, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+
+        let function = instance
+            .exports
+            .get_function("__fp_gen_my_async_exported_function")
+            .map_err(|_| InvocationError::FunctionNotExported)?;
+        let result = function.call(&[])?;
+
+        let async_ptr: FatPtr = match result[0] {
+            Value::I64(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        };
+
+        let raw_result = ModuleRawFuture::new(env.clone(), async_ptr).await;
+        Ok(rmp_serde::from_slice(&raw_result).unwrap())
+    }
+
+    pub fn my_complex_exported_function(&self, a: ComplexHostToGuest) -> Result<ComplexAlias, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+
+        let a = export_to_guest(&env, &a);
+
+        let function = instance
+            .exports
+            .get_function("__fp_gen_my_complex_exported_function")
+            .map_err(|_| InvocationError::FunctionNotExported)?;
+        let result = function.call(&[a.into()])?;
+
+        let ptr: FatPtr = match result[0] {
+            Value::I64(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        };
+
+        Ok(import_from_guest(&env, ptr))
+    }
+
+    pub fn my_plain_exported_function(&self, a: u32, b: u32) -> Result<u32, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+
+        let function = instance
+            .exports
+            .get_function("__fp_gen_my_plain_exported_function")
+            .map_err(|_| InvocationError::FunctionNotExported)?;
+        let result = function.call(&[a.into(), b.into()])?;
+
+        match result[0] {
+            Value::I32(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }
+    }
+
     pub async fn fetch_data_raw(&self, url: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
         let mut env = RuntimeInstanceData::default();
         let import_object = create_import_object(self.module.store(), &env);
         let instance = Instance::new(&self.module, &import_object).unwrap();
         env.init_with_instance(&instance).unwrap();
+
         let url = export_to_guest_raw(&env, url);
+
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_fetch_data")
+            .get_function("__fp_gen_fetch_data")
             .map_err(|_| InvocationError::FunctionNotExported)?;
-        let result = function.call((url))?;
-        let result = ModuleRawFuture::new(env.clone(), result).await;
-        Ok(result)
+        let result = function.call(&[url.into()])?;
+
+        let async_ptr: FatPtr = match result[0] {
+            Value::I64(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        };
+
+        Ok(ModuleRawFuture::new(env.clone(), async_ptr).await)
     }
 
-    pub async fn my_async_exported_function(&self) -> Result<ComplexGuestToHost, InvocationError> {
-        let res = self.my_async_exported_function_raw();
-        let res = res.await?;
-        rmp_serde::from_slice(&res).unwrap()
-    }
     pub async fn my_async_exported_function_raw(&self) -> Result<Vec<u8>, InvocationError> {
         let mut env = RuntimeInstanceData::default();
         let import_object = create_import_object(self.module.store(), &env);
         let instance = Instance::new(&self.module, &import_object).unwrap();
         env.init_with_instance(&instance).unwrap();
+
         let function = instance
             .exports
-            .get_native_function::<(), FatPtr>("__fp_gen_my_async_exported_function")
+            .get_function("__fp_gen_my_async_exported_function")
             .map_err(|_| InvocationError::FunctionNotExported)?;
-        let result = function.call(())?;
-        let result = ModuleRawFuture::new(env.clone(), result).await;
-        Ok(result)
+        let result = function.call(&[])?;
+
+        let async_ptr: FatPtr = match result[0] {
+            Value::I64(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        };
+
+        Ok(ModuleRawFuture::new(env.clone(), async_ptr).await)
     }
 
-    pub fn my_complex_exported_function(
-        &self,
-        a: ComplexHostToGuest,
-    ) -> Result<ComplexAlias, InvocationError> {
-        let a = serialize_to_vec(a);
-        let res = self.my_complex_exported_function_raw(a);
-        rmp_serde::from_slice(&res).unwrap()
-    }
     pub fn my_complex_exported_function_raw(&self, a: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
         let mut env = RuntimeInstanceData::default();
         let import_object = create_import_object(self.module.store(), &env);
         let instance = Instance::new(&self.module, &import_object).unwrap();
         env.init_with_instance(&instance).unwrap();
+
         let a = export_to_guest_raw(&env, a);
+
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_my_complex_exported_function")
+            .get_function("__fp_gen_my_complex_exported_function")
             .map_err(|_| InvocationError::FunctionNotExported)?;
-        let result = function.call((a))?;
-        let result = import_from_guest_raw(&env, result);
-        Ok(result)
+        let result = function.call(&[a.into()])?;
+
+        let ptr: FatPtr = match result[0] {
+            Value::I64(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        };
+
+        Ok(import_from_guest_raw(&env, ptr))
     }
 
-    pub fn my_plain_exported_function(&self, a: u32, b: u32) -> Result<u32, InvocationError> {
-        let res = self.my_plain_exported_function_raw(a, b);
-        rmp_serde::from_slice(&res).unwrap()
-    }
-    pub fn my_plain_exported_function_raw(
-        &self,
-        a: u32,
-        b: u32,
-    ) -> Result<Vec<u8>, InvocationError> {
+    pub fn my_plain_exported_function_raw(&self, a: u32, b: u32) -> Result<u32, InvocationError> {
         let mut env = RuntimeInstanceData::default();
         let import_object = create_import_object(self.module.store(), &env);
         let instance = Instance::new(&self.module, &import_object).unwrap();
         env.init_with_instance(&instance).unwrap();
+
         let function = instance
             .exports
-            .get_native_function::<(u32, u32), u32>("__fp_gen_my_plain_exported_function")
+            .get_function("__fp_gen_my_plain_exported_function")
             .map_err(|_| InvocationError::FunctionNotExported)?;
-        let result = function.call((a, b))?;
-        let result = import_from_guest_raw(&env, result);
-        Ok(result)
+        let result = function.call(&[a.into(), b.into()])?;
+
+        match result[0] {
+            Value::I32(v) => unsafe { std::mem::transmute(v) },
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }
     }
 }
 
 fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObject {
     imports! {
-       "fp" => {
-           "__fp_host_resolve_async_value" => Function :: new_native_with_env (store , env . clone () , resolve_async_value) ,
-           "__fp_gen_count_words" => Function :: new_native_with_env (store , env . clone () , _count_words) ,
-           "__fp_gen_log" => Function :: new_native_with_env (store , env . clone () , _log) ,
-           "__fp_gen_make_request" => Function :: new_native_with_env (store , env . clone () , _make_request) ,
-           "__fp_gen_my_async_imported_function" => Function :: new_native_with_env (store , env . clone () , _my_async_imported_function) ,
-           "__fp_gen_my_complex_imported_function" => Function :: new_native_with_env (store , env . clone () , _my_complex_imported_function) ,
-           "__fp_gen_my_plain_imported_function" => Function :: new_native_with_env (store , env . clone () , _my_plain_imported_function) ,
+        "fp" => {
+            "__fp_host_resolve_async_value" => Function::new_native_with_env(store, env.clone(), resolve_async_value),
+            "__fp_gen_count_words" => Function::new_native_with_env(store, env.clone(), _count_words),
+            "__fp_gen_log" => Function::new_native_with_env(store, env.clone(), _log),
+            "__fp_gen_make_request" => Function::new_native_with_env(store, env.clone(), _make_request),
+            "__fp_gen_my_async_imported_function" => Function::new_native_with_env(store, env.clone(), _my_async_imported_function),
+            "__fp_gen_my_complex_imported_function" => Function::new_native_with_env(store, env.clone(), _my_complex_imported_function),
+            "__fp_gen_my_plain_imported_function" => Function::new_native_with_env(store, env.clone(), _my_plain_imported_function),
         }
     }
 }
 
 pub fn _count_words(env: &RuntimeInstanceData, string: FatPtr) -> FatPtr {
     let string = import_from_guest::<String>(env, string);
-    let result = super::count_words(string);
-    export_to_guest(env, &result)
+
+    export_to_guest(env, &super::count_words(string))
 }
 
 pub fn _log(env: &RuntimeInstanceData, message: FatPtr) {
     let message = import_from_guest::<String>(env, message);
-    let result = super::log(message);
-    ()
+
+    super::log(message);
 }
 
 pub fn _make_request(env: &RuntimeInstanceData, opts: FatPtr) -> FatPtr {
     let opts = import_from_guest::<RequestOptions>(env, opts);
-    let result = super::make_request(opts);
+
     let env = env.clone();
     let async_ptr = create_future_value(&env);
     let handle = tokio::runtime::Handle::current();
     handle.spawn(async move {
-        let result = result.await;
-        let result_ptr = export_to_guest(&env, &result);
+        let result_ptr = export_to_guest(&env, &super::make_request(opts).await);
+
         unsafe {
             env.__fp_guest_resolve_async_value
                 .get_unchecked()
@@ -138,17 +219,17 @@ pub fn _make_request(env: &RuntimeInstanceData, opts: FatPtr) -> FatPtr {
                 .expect("Runtime error: Cannot resolve async value");
         }
     });
+
     async_ptr
 }
 
 pub fn _my_async_imported_function(env: &RuntimeInstanceData) -> FatPtr {
-    let result = super::my_async_imported_function();
     let env = env.clone();
     let async_ptr = create_future_value(&env);
     let handle = tokio::runtime::Handle::current();
     handle.spawn(async move {
-        let result = result.await;
-        let result_ptr = export_to_guest(&env, &result);
+        let result_ptr = export_to_guest(&env, &super::my_async_imported_function().await);
+
         unsafe {
             env.__fp_guest_resolve_async_value
                 .get_unchecked()
@@ -156,16 +237,16 @@ pub fn _my_async_imported_function(env: &RuntimeInstanceData) -> FatPtr {
                 .expect("Runtime error: Cannot resolve async value");
         }
     });
+
     async_ptr
 }
 
 pub fn _my_complex_imported_function(env: &RuntimeInstanceData, a: FatPtr) -> FatPtr {
     let a = import_from_guest::<ComplexAlias>(env, a);
-    let result = super::my_complex_imported_function(a);
-    export_to_guest(env, &result)
+
+    export_to_guest(env, &super::my_complex_imported_function(a))
 }
 
 pub fn _my_plain_imported_function(env: &RuntimeInstanceData, a: u32, b: u32) -> u32 {
-    let result = super::my_plain_imported_function(a, b);
-    result
+    super::my_plain_imported_function(a, b)
 }

--- a/example-protocol/src/main.rs
+++ b/example-protocol/src/main.rs
@@ -1,4 +1,4 @@
-use fp_bindgen::prelude::*;
+use fp_bindgen::{prelude::*, WasmerRuntimeConfig};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use std::collections::{BTreeMap, HashMap};
@@ -171,7 +171,9 @@ fn main() {
                 r#"{ path = "../../fp-bindgen-support", features = ["async"] }"#.to_owned(),
             )]),
         }),
-        BindingsType::RustWasmerRuntime,
+        BindingsType::RustWasmerRuntime(WasmerRuntimeConfig {
+            generate_raw_export_wrappers: true,
+        }),
         BindingsType::TsRuntime(TsRuntimeConfig {
             generate_raw_export_wrappers: true,
         }),
@@ -242,7 +244,9 @@ fn test_generate_rust_wasmer_runtime() {
         ),
     ];
     fp_bindgen!(BindingConfig {
-        bindings_type: BindingsType::RustWasmerRuntime,
+        bindings_type: BindingsType::RustWasmerRuntime(WasmerRuntimeConfig {
+            generate_raw_export_wrappers: true
+        }),
         path: "bindings/rust-wasmer-runtime",
     });
     for (path, expected) in FILES {

--- a/fp-bindgen/Cargo.toml
+++ b/fp-bindgen/Cargo.toml
@@ -20,4 +20,3 @@ quote = "1"
 serde_bytes = { version = "0.11", optional = true }
 syn = { version = "1", features = ["full", "extra-traits"] }
 time = { version = "0.3", optional = true }
-rustfmt-wrapper = "0.1.0"

--- a/fp-bindgen/src/functions.rs
+++ b/fp-bindgen/src/functions.rs
@@ -2,9 +2,9 @@ use crate::{
     docs::get_doc_lines,
     types::{resolve_type_or_panic, Type},
 };
-use quote::{format_ident, quote, ToTokens};
+use quote::ToTokens;
 use std::collections::BTreeSet;
-use syn::{token::Async, FnArg, ForeignItemFn, ReturnType};
+use syn::{FnArg, ForeignItemFn, ReturnType};
 
 /// Maps from function name to the stringified function declaration.
 #[derive(Debug, Default)]
@@ -122,81 +122,8 @@ impl PartialOrd for Function {
     }
 }
 
-impl ToTokens for Function {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let Self {
-            name,
-            args,
-            doc_lines,
-            is_async,
-            return_type,
-        } = self;
-
-        let name = format_ident!("{}", name);
-
-        let asyncness = is_async.then(|| Async {
-            ..Default::default()
-        });
-
-        (quote! {
-            #(#[doc = #doc_lines])*
-            #asyncness fn #name(#(#args),*) -> #return_type
-        })
-        .to_tokens(tokens);
-    }
-}
-
 #[derive(Debug, Eq, PartialEq)]
 pub struct FunctionArg {
     pub name: String,
     pub ty: Type,
-}
-
-impl ToTokens for FunctionArg {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let Self { name, ty } = self;
-        let name = format_ident!("{}", name);
-
-        (quote! {
-            #name: #ty
-        })
-        .to_tokens(tokens)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::{Function, FunctionArg};
-    use crate::{primitives::Primitive, types::Type};
-    use quote::ToTokens;
-
-    #[test]
-    fn test_function_arg_to_tokens() {
-        let arg = FunctionArg {
-            name: "foobar".into(),
-            ty: Type::Primitive(Primitive::I64),
-        };
-
-        let stringified = arg.into_token_stream().to_string();
-
-        pretty_assertions::assert_eq!(&stringified, "foobar : i64");
-    }
-
-    #[test]
-    fn test_function_to_tokens() {
-        let func = Function {
-            name: "foobar".into(),
-            is_async: false,
-            doc_lines: vec![],
-            return_type: Type::String,
-            args: vec![FunctionArg {
-                name: "a1".into(),
-                ty: Type::Primitive(Primitive::U64),
-            }],
-        };
-
-        let string = func.into_token_stream().to_string();
-
-        pretty_assertions::assert_eq!(&string, "fn foobar (a1 : u64) -> String");
-    }
 }

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -568,6 +568,15 @@ pub fn format_type(ty: &Type) -> String {
     }
 }
 
+/// Formats types so that all complex types are replaced with the raw serialized version
+pub fn format_raw_type(ty: &Type) -> String {
+    match ty {
+        Type::Primitive(primitive) => format_primitive(*primitive),
+        Type::Unit => "()".to_owned(),
+        _ => "Vec<u8>".to_string(),
+    }
+}
+
 pub fn format_primitive(primitive: Primitive) -> String {
     let string = match primitive {
         Primitive::Bool => "bool",

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/assets/support.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/assets/support.rs
@@ -83,15 +83,11 @@ pub(crate) fn import_from_guest_raw(env: &RuntimeInstanceData, fat_ptr: FatPtr) 
     value
 }
 
-pub(crate) fn serialize_to_vec<T: Serialize>(value: &T) -> Vec<u8> {
-    let mut buffer = Vec::new();
-    value.serialize(&mut Serializer::new(&mut buffer)).unwrap();
-    buffer
-}
-
 /// Serialize a value and put it in linear memory.
 pub(crate) fn export_to_guest<T: Serialize>(env: &RuntimeInstanceData, value: &T) -> FatPtr {
-    let buffer = serialize_to_vec(value);
+    let mut buffer = Vec::new();
+    value.serialize(&mut Serializer::new(&mut buffer)).unwrap();
+
     export_to_guest_raw(env, buffer)
 }
 

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -1,17 +1,20 @@
-use crate::functions::{Function, FunctionArg, FunctionList};
-use crate::generators::rust_plugin::generate_type_bindings;
+use crate::functions::{Function, FunctionList};
+use crate::generators::rust_plugin::{
+    format_primitive, format_raw_type, format_type, generate_type_bindings,
+};
+use crate::primitives::Primitive;
 use crate::types::Type;
-use proc_macro2::{Punct, TokenStream};
-use quote::{format_ident, quote, ToTokens};
+use crate::WasmerRuntimeConfig;
 use std::collections::BTreeSet;
 use std::fs;
-use syn::token::Async;
+use std::iter;
 
 pub fn generate_bindings(
     import_functions: FunctionList,
     export_functions: FunctionList,
     serializable_types: BTreeSet<Type>,
     deserializable_types: BTreeSet<Type>,
+    runtime_config: WasmerRuntimeConfig,
     path: &str,
 ) {
     let spec_path = format!("{}/spec", path);
@@ -26,7 +29,12 @@ pub fn generate_bindings(
         "rust_wasmer_runtime",
     );
 
-    generate_function_bindings(import_functions, export_functions, &spec_path);
+    generate_function_bindings(
+        import_functions,
+        export_functions,
+        runtime_config.generate_raw_export_wrappers,
+        &spec_path,
+    );
 
     write_bindings_file(
         format!("{}/errors.rs", path),
@@ -39,274 +47,407 @@ pub fn generate_bindings(
     );
 }
 
-fn generate_create_import_object_func(import_functions: &FunctionList) -> TokenStream {
-    //yes this is pretty ugly but fortunately *only* required here to get proper formatting with quote!
-    //since rustfmt doesn't format inside macro invocations :(
-    let newline = Punct::new('\n', proc_macro2::Spacing::Alone);
-    let space = Punct::new(' ', proc_macro2::Spacing::Joint);
-    let spaces4: Vec<_> = (0..3).map(|_| &space).collect();
-    let spaces8: Vec<_> = (0..7).map(|_| &space).collect();
-    let spaces8 = quote! {#(#spaces8)*};
-
-    let fp_gen_names = import_functions
-        .iter()
-        .map(|function| format!("__fp_gen_{}", function.name));
-    let names = import_functions
-        .iter()
-        .map(|function| format_ident!("_{}", function.name));
-
-    quote! {
-        fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObject {
-            imports! {
-                #newline
-                #(#spaces4)* "fp" => {
-                    #newline
-                    #spaces8 "__fp_host_resolve_async_value" => Function::new_native_with_env(store, env.clone(), resolve_async_value),
-                    #newline
-                    #(
-                        #spaces8 #fp_gen_names => Function::new_native_with_env(store, env.clone(), #names),
-                        #newline
-                    )*
-                #(#spaces4)* }
-                #newline
-            }
-        }
-    }
-}
-
-pub struct ExportSafeFunctionArg<'a>(pub &'a FunctionArg);
-
-impl ToTokens for ExportSafeFunctionArg<'_> {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let name = format_ident!("{}", self.0.name);
-        let ty = ExportSafeType(&self.0.ty);
-        quote!(#name: #ty).to_tokens(tokens)
-    }
-}
-
-pub struct ExportSafeType<'a>(pub &'a Type);
-
-impl ToTokens for ExportSafeType<'_> {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        match self.0 {
-            Type::Primitive(p) => quote! {#p},
-            _ => quote! {FatPtr},
-        }
-        .to_tokens(tokens)
-    }
-}
-
-struct ComplexArgsToVec<'a>(&'a FunctionArg);
-
-impl ToTokens for ComplexArgsToVec<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let name = format_ident!("{}", self.0.name);
-        let ty = match self.0.ty {
-            Type::Primitive(p) => quote! {#p},
-            _ => (quote! {Vec<u8>}),
-        };
-        (quote! {#name: #ty}).to_tokens(tokens)
-    }
-}
-
-struct RuntimeImportedFunction<'a>(&'a Function);
-
-impl ToTokens for RuntimeImportedFunction<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let newline = Punct::new('\n', proc_macro2::Spacing::Alone);
-
-        let Function {
-            name,
-            doc_lines,
-            args,
-            return_type,
-            is_async,
-        } = self.0;
-
-        let fp_gen_name = format!("__fp_gen_{}", name);
-        let raw_name = format_ident!("{}_raw", name);
-        let name = format_ident!("{}", name);
-
-        let arg_names: Vec<_> = args.iter().map(|a| format_ident!("{}", a.name)).collect();
-        let serialize_names: Vec<_> = args
-            .iter()
-            .filter_map(|a| {
-                (!matches!(a.ty, Type::Primitive(..))).then(|| format_ident!("{}", a.name))
-            })
-            .collect();
-        let raw_format_args = args.iter().map(ComplexArgsToVec);
-        let safe_arg_types = args.iter().map(|a| ExportSafeType(&a.ty));
-        let safe_return_type = ExportSafeType(return_type);
-
-        let asyncness = is_async.then(Async::default);
-        let awaiter = is_async.then(|| quote! {let res = res.await?;});
-
-        let return_wrapper = if *is_async {
-            quote! {
-                let result = ModuleRawFuture::new(env.clone(), result).await;
-            }
-        } else {
-            quote! {
-                let result = import_from_guest_raw(&env, result);
-            }
-        };
-
-        (quote! {
-            #(#[doc = #doc_lines])*
-            pub #asyncness fn #name(&self #(,#args)*) -> Result<#return_type, InvocationError> {
-                #(let #serialize_names = serialize_to_vec(#serialize_names);)*
-
-                let res = self.#raw_name(#(#arg_names),*);
-
-                #awaiter
-
-                rmp_serde::from_slice(&res).unwrap()
-            }
-
-            pub #asyncness fn #raw_name(&self #(,#raw_format_args)*) -> Result<Vec<u8>, InvocationError> {
-                let mut env = RuntimeInstanceData::default();
-                let import_object = create_import_object(self.module.store(), &env);
-                let instance = Instance::new(&self.module, &import_object).unwrap();
-                env.init_with_instance(&instance).unwrap();
-
-                #(let #serialize_names = export_to_guest_raw(&env, #serialize_names);)*
-
-                let function = instance
-                    .exports
-                    .get_native_function::<(#(#safe_arg_types),*), #safe_return_type>(#fp_gen_name)
-                    .map_err(|_| InvocationError::FunctionNotExported)?;
-
-                let result = function.call((#(#arg_names),*))?;
-
-                #return_wrapper
-
-                Ok(result)
-            }
-            #newline
-            #newline
-            #newline
-        })
-        .to_tokens(tokens)
-    }
-}
-
-struct RuntimeExportedFunction<'a>(&'a Function);
-
-impl ToTokens for RuntimeExportedFunction<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Function {
-            name,
-            args,
-            is_async,
-            return_type,
-            ..
-        } = self.0;
-
-        let underscore_name = format_ident!("_{}", name);
-        let input_args = args.iter().map(ExportSafeFunctionArg);
-        let wrapper_return_type = if *is_async {
-            quote! {-> FatPtr}
-        } else if matches!(return_type, Type::Unit) {
-            TokenStream::default()
-        } else {
-            let est = ExportSafeType(return_type);
-            quote! {-> #est}
-        };
-
-        let complex_args = args
-            .iter()
-            .filter(|a| !matches!(a.ty, Type::Primitive(_)))
-            .collect::<Vec<_>>();
-        let complex_types = complex_args.iter().map(|a| &a.ty);
-        let complex_idents = complex_args
-            .iter()
-            .map(|a| format_ident!("{}", a.name))
-            .collect::<Vec<_>>();
-
-        let impl_func_name = format_ident!("{}", name);
-        let arg_idents = args.iter().map(|a| format_ident!("{}", a.name));
-        let func_call = quote!(super::#impl_func_name(#(#arg_idents),*));
-
-        let wrapper = if *is_async {
-            quote! {
-                let env = env.clone();
-                let async_ptr = create_future_value(&env);
-                let handle = tokio::runtime::Handle::current();
-                handle.spawn(async move {
-                    let result = result.await;
-                    let result_ptr = export_to_guest(&env, &result);
-                    unsafe {
-                        env.__fp_guest_resolve_async_value
-                            .get_unchecked()
-                            .call(async_ptr, result_ptr)
-                            .expect("Runtime error: Cannot resolve async value");
-                    }
-                });
-                async_ptr
-            }
-        } else {
-            match return_type {
-                Type::Primitive(_) => quote! {result},
-                Type::Unit => quote! {()},
-                _ => quote! {export_to_guest(env, &result)},
-            }
-        };
-
-        let newline = Punct::new('\n', proc_macro2::Spacing::Alone);
-
-        (quote! {
-            pub fn #underscore_name(env: &RuntimeInstanceData #(,#input_args)*) #wrapper_return_type {
-                #(let #complex_idents = import_from_guest::<#complex_types>(env, #complex_idents);)*
-
-                let result = #func_call;
-                #wrapper
-            }
-            #newline
-            #newline
-        }).to_tokens(tokens)
-    }
-}
-
 pub fn generate_function_bindings(
     import_functions: FunctionList,
     export_functions: FunctionList,
+    generate_raw_export_wrappers: bool,
     path: &str,
 ) {
-    let newline = Punct::new('\n', proc_macro2::Spacing::Alone);
-    let create_import_object_func = generate_create_import_object_func(&import_functions);
+    let imports_map = import_functions
+        .iter()
+        .map(|function| {
+            let name = &function.name;
+            format!(
+                "            \"__fp_gen_{}\" => Function::new_native_with_env(store, env.clone(), _{}),",
+                name, name
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
 
-    let imports = import_functions.iter().map(RuntimeExportedFunction);
-    let exports = export_functions.iter().map(RuntimeImportedFunction);
+    let imports = import_functions
+        .iter()
+        .map(|function| {
+            let name = &function.name;
+            let args_with_types = function
+                .args
+                .iter()
+                .map(|arg| {
+                    format!(
+                        ", {}: {}",
+                        arg.name,
+                        match arg.ty {
+                            Type::Primitive(primitive) => format_primitive(primitive),
+                            _ => "FatPtr".to_owned(),
+                        }
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            let import_args = function
+                .args
+                .iter()
+                .map(|arg| match &arg.ty {
+                    Type::Primitive(_) => "".to_owned(),
+                    _ => format!(
+                        "    let {} = import_from_guest::<{}>(env, {});\n",
+                        arg.name,
+                        format_type(&arg.ty),
+                        arg.name
+                    ),
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            let return_type = if function.is_async {
+                " -> FatPtr".to_owned()
+            } else {
+                match &function.return_type {
+                    Type::Unit => "".to_owned(),
+                    ty => format!(
+                        " -> {}",
+                        match ty {
+                            Type::Primitive(primitive) => format_primitive(*primitive),
+                            _ => "FatPtr".to_owned(),
+                        }
+                    ),
+                }
+            };
+            let args = function
+                .args
+                .iter()
+                .map(|arg| arg.name.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let call_fn = if function.is_async {
+                let call_async_fn = match &function.return_type {
+                    Type::Unit => format!(
+                        "super::{}({}).await;\n        let result_ptr = 0;",
+                        name, args
+                    ),
+                    _ => format!(
+                        "let result_ptr = export_to_guest(&env, &super::{}({}).await);",
+                        name, args
+                    ),
+                };
 
-    let full = rustfmt_wrapper::rustfmt(quote! {
-        use super::types::*;
-        use crate::errors::InvocationError;
-        use crate::{
-            support::{
-                create_future_value, export_to_guest, export_to_guest_raw, import_from_guest,
-                resolve_async_value, FatPtr, ModuleRawFuture,
-            },
-            Runtime, RuntimeInstanceData,
-        };
-        use wasmer::{imports, Function, ImportObject, Instance, Store, Value, WasmerEnv};
-        #newline
-        #newline
-        impl Runtime {
-            #(#exports)*
+                format!(
+                    "let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {{
+        {}
+
+        unsafe {{
+            env.__fp_guest_resolve_async_value
+                .get_unchecked()
+                .call(async_ptr, result_ptr)
+                .expect(\"Runtime error: Cannot resolve async value\");
+        }}
+    }});
+
+    async_ptr",
+                    call_async_fn
+                )
+            } else {
+                match &function.return_type {
+                    Type::Unit => format!("super::{}({});", name, args),
+                    Type::Primitive(_) => format!("super::{}({})", name, args),
+                    _ => format!("export_to_guest(env, &super::{}({}))", name, args),
+                }
+            };
+            format!(
+                "pub fn _{}(env: &RuntimeInstanceData{}){} {{
+{}{}    {}
+}}",
+                name,
+                args_with_types,
+                return_type,
+                import_args,
+                if import_args.is_empty() { "" } else { "\n" },
+                call_fn
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let exports = export_functions
+        .iter()
+        .map(export_function)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let raw_exports = if generate_raw_export_wrappers {
+        // add a newline between the raw exports and the exports
+        iter::once("".to_string())
+            .chain(export_functions.iter().map(export_raw_function))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    } else {
+        String::new()
+    };
+
+    write_bindings_file(
+        format!("{}/bindings.rs", path),
+        format!(
+            "use super::types::*;
+use crate::errors::InvocationError;
+use crate::{{
+    support::{{
+        create_future_value, export_to_guest, export_to_guest_raw, import_from_guest,
+        resolve_async_value, FatPtr, ModuleRawFuture,
+    }},
+    Runtime, RuntimeInstanceData,
+}};
+use wasmer::{{imports, Function, ImportObject, Instance, Store, Value, WasmerEnv}};
+
+impl Runtime {{
+{}{}
+}}
+
+fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObject {{
+    imports! {{
+        \"fp\" => {{
+            \"__fp_host_resolve_async_value\" => Function::new_native_with_env(store, env.clone(), resolve_async_value),
+{}
+        }}
+    }}
+}}
+
+{}
+",
+            exports, raw_exports, imports_map, imports,
+        ),
+    );
+}
+
+fn export_function(function: &Function) -> String {
+    let doc = function
+        .doc_lines
+        .iter()
+        .map(|line| format!("    ///{}\n", line))
+        .collect::<Vec<_>>()
+        .join("");
+    let modifiers = if function.is_async { "async " } else { "" };
+    let args_with_types = function
+        .args
+        .iter()
+        .map(|arg| format!(", {}: {}", arg.name, format_type(&arg.ty)))
+        .collect::<Vec<_>>()
+        .join("");
+    let return_type = format!(
+        " -> Result<{}, InvocationError>",
+        format_type(&function.return_type)
+    );
+    let export_args = function
+        .args
+        .iter()
+        .map(|arg| match &arg.ty {
+            Type::Primitive(_) => "".to_owned(),
+            _ => format!(
+                "        let {} = export_to_guest(&env, &{});\n",
+                arg.name, arg.name
+            ),
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    let args = function
+        .args
+        .iter()
+        .map(|arg| format!("{}.into()", arg.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let call_and_return = if function.is_async {
+        format!(
+            "let result = function.call(&[{}])?;
+
+        let async_ptr: FatPtr = match result[0] {{
+            Value::I64(v) => unsafe {{ std::mem::transmute(v) }},
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }};
+
+        let raw_result = ModuleRawFuture::new(env.clone(), async_ptr).await;
+        Ok(rmp_serde::from_slice(&raw_result).unwrap())",
+            args
+        )
+    } else {
+        match function.return_type {
+            Type::Unit => format!("function.call(&[{}])?;", args),
+            Type::Primitive(primitive) => {
+                use Primitive::*;
+                let transmute = match primitive {
+                    Bool => "Value::I32(v) => v as bool",
+                    F32 => "Value::F32(v) => v",
+                    F64 => "Value::F64(v) => v",
+                    I8 => "Value::I32(v) => v as i8",
+                    I16 => "Value::I32(v) => v as i16",
+                    I32 => "Value::I32(v) => v",
+                    I64 => "Value::I64(v) => v",
+                    U8 => "Value::I32(v) => v as u8",
+                    U16 => "Value::I32(v) => v as u16",
+                    U32 => "Value::I32(v) => unsafe { std::mem::transmute(v) }",
+                    U64 => "Value::I64(v) => unsafe { std::mem::transmute(v) }",
+                };
+
+                format!(
+                    "let result = function.call(&[{}])?;
+
+        match result[0] {{
+            {},
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }}",
+                    args, transmute
+                )
+            }
+            _ => format!(
+                "let result = function.call(&[{}])?;
+
+        let ptr: FatPtr = match result[0] {{
+            Value::I64(v) => unsafe {{ std::mem::transmute(v) }},
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }};
+
+        Ok(import_from_guest(&env, ptr))",
+                args
+            ),
         }
-        #newline
-        #newline
+    };
+    format!(
+        "{}    pub {}fn {}(&self{}){} {{
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
 
-        #create_import_object_func
+{}{}        let function = instance
+            .exports
+            .get_function(\"__fp_gen_{}\")
+            .map_err(|_| InvocationError::FunctionNotExported)?;
+        {}
+    }}",
+        doc,
+        modifiers,
+        function.name,
+        args_with_types,
+        return_type,
+        export_args,
+        if export_args.is_empty() { "" } else { "\n" },
+        function.name,
+        call_and_return
+    )
+}
 
-        #newline
-        #newline
-        #(#imports)*
+fn export_raw_function(function: &Function) -> String {
+    let doc = function
+        .doc_lines
+        .iter()
+        .map(|line| format!("    ///{}\n", line))
+        .collect::<Vec<_>>()
+        .join("");
+    let modifiers = if function.is_async { "async " } else { "" };
+    let args_with_types = function
+        .args
+        .iter()
+        .map(|arg| format!(", {}: {}", arg.name, format_raw_type(&arg.ty)))
+        .collect::<Vec<_>>()
+        .join("");
+    let return_type = format!(
+        " -> Result<{}, InvocationError>",
+        format_raw_type(&function.return_type)
+    );
+    let export_args = function
+        .args
+        .iter()
+        .map(|arg| match &arg.ty {
+            Type::Primitive(_) => "".to_owned(),
+            _ => format!(
+                "        let {} = export_to_guest_raw(&env, {});\n",
+                arg.name, arg.name
+            ),
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    let args = function
+        .args
+        .iter()
+        .map(|arg| format!("{}.into()", arg.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let call_and_return = if function.is_async {
+        format!(
+            "let result = function.call(&[{}])?;
 
-    })
-    .unwrap();
+        let async_ptr: FatPtr = match result[0] {{
+            Value::I64(v) => unsafe {{ std::mem::transmute(v) }},
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }};
 
-    write_bindings_file(format!("{}/bindings.rs", path), full);
+        Ok(ModuleRawFuture::new(env.clone(), async_ptr).await)",
+            args
+        )
+    } else {
+        match function.return_type {
+            Type::Unit => format!("function.call(&[{}])?;", args),
+            Type::Primitive(primitive) => {
+                use Primitive::*;
+                let transmute = match primitive {
+                    Bool => "Value::I32(v) => v as bool",
+                    F32 => "Value::F32(v) => v",
+                    F64 => "Value::F64(v) => v",
+                    I8 => "Value::I32(v) => v as i8",
+                    I16 => "Value::I32(v) => v as i16",
+                    I32 => "Value::I32(v) => v",
+                    I64 => "Value::I64(v) => v",
+                    U8 => "Value::I32(v) => v as u8",
+                    U16 => "Value::I32(v) => v as u16",
+                    U32 => "Value::I32(v) => unsafe { std::mem::transmute(v) }",
+                    U64 => "Value::I64(v) => unsafe { std::mem::transmute(v) }",
+                };
+
+                format!(
+                    "let result = function.call(&[{}])?;
+
+        match result[0] {{
+            {},
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }}",
+                    args, transmute
+                )
+            }
+            _ => format!(
+                "let result = function.call(&[{}])?;
+
+        let ptr: FatPtr = match result[0] {{
+            Value::I64(v) => unsafe {{ std::mem::transmute(v) }},
+            _ => return Err(InvocationError::UnexpectedReturnType),
+        }};
+
+        Ok(import_from_guest_raw(&env, ptr))",
+                args
+            ),
+        }
+    };
+    format!(
+        "{}    pub {}fn {}_raw(&self{}){} {{
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+
+{}{}        let function = instance
+            .exports
+            .get_function(\"__fp_gen_{}\")
+            .map_err(|_| InvocationError::FunctionNotExported)?;
+        {}
+    }}",
+        doc,
+        modifiers,
+        function.name,
+        args_with_types,
+        return_type,
+        export_args,
+        if export_args.is_empty() { "" } else { "\n" },
+        function.name,
+        call_and_return
+    )
 }
 
 fn write_bindings_file<C>(file_path: String, contents: C)
@@ -314,24 +455,4 @@ where
     C: AsRef<[u8]>,
 {
     fs::write(&file_path, &contents).expect("Could not write bindings file");
-}
-
-#[cfg(test)]
-mod test {
-    use super::ExportSafeFunctionArg;
-    use crate::{functions::FunctionArg, types::Type};
-    use quote::ToTokens;
-
-    #[test]
-    fn test_function_arg_to_tokens() {
-        let arg = FunctionArg {
-            name: "foobar".into(),
-            ty: Type::String,
-        };
-        let arg = ExportSafeFunctionArg(&arg);
-
-        let stringified = arg.into_token_stream().to_string();
-
-        pretty_assertions::assert_eq!(&stringified, "foobar : FatPtr");
-    }
 }

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -22,7 +22,7 @@ primitive_impls!();
 #[derive(Debug, Clone)]
 pub enum BindingsType<'a> {
     RustPlugin(RustPluginConfig<'a>),
-    RustWasmerRuntime,
+    RustWasmerRuntime(WasmerRuntimeConfig),
     TsRuntime(TsRuntimeConfig),
 }
 
@@ -49,6 +49,10 @@ pub struct RustPluginConfig<'a> {
     pub version: &'a str,
     pub dependencies: BTreeMap<String, String>,
 }
+#[derive(Debug, Clone)]
+pub struct WasmerRuntimeConfig {
+    pub generate_raw_export_wrappers: bool,
+}
 
 #[derive(Debug, Clone)]
 pub struct TsRuntimeConfig {
@@ -73,13 +77,16 @@ pub fn generate_bindings(
             plugin_config,
             config.path,
         ),
-        BindingsType::RustWasmerRuntime => generators::rust_wasmer_runtime::generate_bindings(
-            import_functions,
-            export_functions,
-            serializable_types,
-            deserializable_types,
-            config.path,
-        ),
+        BindingsType::RustWasmerRuntime(runtime_config) => {
+            generators::rust_wasmer_runtime::generate_bindings(
+                import_functions,
+                export_functions,
+                serializable_types,
+                deserializable_types,
+                runtime_config,
+                config.path,
+            )
+        }
         BindingsType::TsRuntime(runtime_config) => generators::ts_runtime::generate_bindings(
             import_functions,
             export_functions,

--- a/fp-bindgen/src/primitives.rs
+++ b/fp-bindgen/src/primitives.rs
@@ -1,4 +1,3 @@
-use quote::{quote, ToTokens};
 use std::str::FromStr;
 
 /// Type of primitive that is supported out-of-the-box.
@@ -56,24 +55,5 @@ impl FromStr for Primitive {
             string => return Err(format!("Unknown primitive type: \"{}\"", string)),
         };
         Ok(primitive)
-    }
-}
-
-impl ToTokens for Primitive {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        (match self {
-            Primitive::Bool => quote! {bool},
-            Primitive::F32 => quote! {f32},
-            Primitive::F64 => quote! {f64},
-            Primitive::I8 => quote! {i8},
-            Primitive::I16 => quote! {i16},
-            Primitive::I32 => quote! {i32},
-            Primitive::I64 => quote! {i64},
-            Primitive::U8 => quote! {u8},
-            Primitive::U16 => quote! {u16},
-            Primitive::U32 => quote! {u32},
-            Primitive::U64 => quote! {u64},
-        })
-        .to_tokens(tokens)
     }
 }

--- a/fp-bindgen/src/types/mod.rs
+++ b/fp-bindgen/src/types/mod.rs
@@ -1,17 +1,17 @@
 use crate::primitives::Primitive;
-pub use enums::{EnumOptions, Variant, VariantAttrs};
-use quote::quote;
 use quote::ToTokens;
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet},
     hash::{Hash, Hasher},
     str::FromStr,
 };
-pub use structs::{Field, FieldAttrs, StructOptions};
 use syn::{Item, PathArguments};
 
 mod enums;
 mod structs;
+
+pub use enums::{EnumOptions, Variant, VariantAttrs};
+pub use structs::{Field, FieldAttrs, StructOptions};
 
 /// A generic argument has a name (T, E, ...) and an optional type, which is only known in contexts
 /// when we are dealing with concrete instances of the generic type.
@@ -19,13 +19,6 @@ mod structs;
 pub struct GenericArgument {
     pub name: String,
     pub ty: Option<Type>,
-}
-
-impl ToTokens for GenericArgument {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let ty = syn::parse_str::<syn::Type>(&self.name).unwrap();
-        (quote! {#ty}).to_tokens(tokens)
-    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -182,39 +175,6 @@ impl Ord for Type {
 impl PartialOrd for Type {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.ord_key().partial_cmp(&other.ord_key())
-    }
-}
-
-impl ToTokens for Type {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        (match self {
-            Type::Alias(name, _) | Type::Custom(CustomType { rs_ty: name, .. }) => {
-                let ty = syn::parse_str::<syn::Type>(name).unwrap();
-                quote! {#ty}
-            }
-            Type::Container(name, ty) | Type::List(name, ty) => {
-                let name = syn::parse_str::<syn::Type>(name).unwrap();
-                quote! {#name<#ty>}
-            }
-            Type::Struct(name, generic_args, _, _, _) | Type::Enum(name, generic_args, _, _, _) => {
-                let ty = syn::parse_str::<syn::Type>(name).unwrap();
-                if generic_args.is_empty() {
-                    quote! {#ty}
-                } else {
-                    quote! {#ty<#(#generic_args),*>}
-                }
-            }
-            Type::GenericArgument(arg) => quote! {#arg},
-            Type::Map(name, k, v) => {
-                let name = syn::parse_str::<syn::Type>(name).unwrap();
-                quote! {#name<#k,#v>}
-            }
-            Type::Primitive(primitive) => quote! {#primitive},
-            Type::String => quote! {String},
-            Type::Tuple(items) => quote! {(#(#items),*)},
-            Type::Unit => quote! {()},
-        })
-        .to_tokens(tokens)
     }
 }
 


### PR DESCRIPTION
This reverts commit 37bd9e17f9be4448722d8d7d68d1b692f5e21390.

This branch is not intended for merging! It merely serves as a target for FiberKit, while @Zagitta can move the `Serializable` trait to the `fp-bindgen-support` library.