### PR TITLE
Move fp-bindgen generators under feature flag

### DIFF
--- a/example-protocol/Cargo.toml
+++ b/example-protocol/Cargo.toml
@@ -5,7 +5,11 @@ authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 
 [dependencies]
-fp-bindgen = { path = "../fp-bindgen", features = ["serde-bytes-compat", "time-compat"] }
+fp-bindgen = { path = "../fp-bindgen", features = [
+    "serde-bytes-compat",
+    "time-compat",
+    "generators",
+] }
 pretty_assertions = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/fp-bindgen/Cargo.toml
+++ b/fp-bindgen/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 default = ["time-compat", "serde-bytes-compat"]
 serde-bytes-compat = ["serde_bytes"]
 time-compat = ["time"]
+generators = ["rustfmt-wrapper"]
 
 [dependencies]
 dashmap = "4"
@@ -20,4 +21,4 @@ quote = "1"
 serde_bytes = { version = "0.11", optional = true }
 syn = { version = "1", features = ["full", "extra-traits"] }
 time = { version = "0.3", optional = true }
-rustfmt-wrapper = "0.1.0"
+rustfmt-wrapper = { version = "0.1.0", optional = true }

--- a/fp-bindgen/src/generators/mod.rs
+++ b/fp-bindgen/src/generators/mod.rs
@@ -1,3 +1,82 @@
 pub mod rust_plugin;
 pub mod rust_wasmer_runtime;
 pub mod ts_runtime;
+
+use crate::{functions::FunctionList, types::Type};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Display,
+    fs,
+};
+
+#[derive(Debug, Clone)]
+pub enum BindingsType<'a> {
+    RustPlugin(RustPluginConfig<'a>),
+    RustWasmerRuntime,
+    TsRuntime(TsRuntimeConfig),
+}
+
+impl<'a> Display for BindingsType<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            BindingsType::RustPlugin { .. } => "rust-plugin",
+            BindingsType::RustWasmerRuntime { .. } => "rust-wasmer-runtime",
+            BindingsType::TsRuntime { .. } => "ts-runtime",
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct BindingConfig<'a> {
+    pub bindings_type: BindingsType<'a>,
+    pub path: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct RustPluginConfig<'a> {
+    pub name: &'a str,
+    pub authors: &'a str,
+    pub version: &'a str,
+    pub dependencies: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TsRuntimeConfig {
+    pub generate_raw_export_wrappers: bool,
+}
+
+pub fn generate_bindings(
+    import_functions: FunctionList,
+    export_functions: FunctionList,
+    serializable_types: BTreeSet<Type>,
+    deserializable_types: BTreeSet<Type>,
+    config: BindingConfig,
+) {
+    fs::create_dir_all(config.path).expect("Could not create output directory");
+
+    match config.bindings_type {
+        BindingsType::RustPlugin(plugin_config) => rust_plugin::generate_bindings(
+            import_functions,
+            export_functions,
+            serializable_types,
+            deserializable_types,
+            plugin_config,
+            config.path,
+        ),
+        BindingsType::RustWasmerRuntime => rust_wasmer_runtime::generate_bindings(
+            import_functions,
+            export_functions,
+            serializable_types,
+            deserializable_types,
+            config.path,
+        ),
+        BindingsType::TsRuntime(runtime_config) => ts_runtime::generate_bindings(
+            import_functions,
+            export_functions,
+            serializable_types,
+            deserializable_types,
+            runtime_config,
+            config.path,
+        ),
+    };
+}

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -1,6 +1,7 @@
 mod casing;
 mod docs;
 mod functions;
+#[cfg(feature = "generators")]
 mod generators;
 mod serializable;
 
@@ -11,82 +12,11 @@ pub mod types;
 
 use fp_bindgen_macros::primitive_impls;
 use prelude::*;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Display,
-    fs,
-};
+use std::collections::BTreeSet;
 
 primitive_impls!();
 
-#[derive(Debug, Clone)]
-pub enum BindingsType<'a> {
-    RustPlugin(RustPluginConfig<'a>),
-    RustWasmerRuntime,
-    TsRuntime(TsRuntimeConfig),
-}
-
-impl<'a> Display for BindingsType<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            BindingsType::RustPlugin { .. } => "rust-plugin",
-            BindingsType::RustWasmerRuntime { .. } => "rust-wasmer-runtime",
-            BindingsType::TsRuntime { .. } => "ts-runtime",
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct BindingConfig<'a> {
-    pub bindings_type: BindingsType<'a>,
-    pub path: &'a str,
-}
-
-#[derive(Debug, Clone)]
-pub struct RustPluginConfig<'a> {
-    pub name: &'a str,
-    pub authors: &'a str,
-    pub version: &'a str,
-    pub dependencies: BTreeMap<String, String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct TsRuntimeConfig {
-    pub generate_raw_export_wrappers: bool,
-}
-
-pub fn generate_bindings(
-    import_functions: FunctionList,
-    export_functions: FunctionList,
-    serializable_types: BTreeSet<Type>,
-    deserializable_types: BTreeSet<Type>,
-    config: BindingConfig,
-) {
-    fs::create_dir_all(config.path).expect("Could not create output directory");
-
-    match config.bindings_type {
-        BindingsType::RustPlugin(plugin_config) => generators::rust_plugin::generate_bindings(
-            import_functions,
-            export_functions,
-            serializable_types,
-            deserializable_types,
-            plugin_config,
-            config.path,
-        ),
-        BindingsType::RustWasmerRuntime => generators::rust_wasmer_runtime::generate_bindings(
-            import_functions,
-            export_functions,
-            serializable_types,
-            deserializable_types,
-            config.path,
-        ),
-        BindingsType::TsRuntime(runtime_config) => generators::ts_runtime::generate_bindings(
-            import_functions,
-            export_functions,
-            serializable_types,
-            deserializable_types,
-            runtime_config,
-            config.path,
-        ),
-    };
-}
+#[cfg(feature = "generators")]
+pub use generators::{
+    generate_bindings, BindingConfig, BindingsType, RustPluginConfig, TsRuntimeConfig,
+};


### PR DESCRIPTION
This isolates `rustfmt-wrapper` from the WASM side to avoid the issues that causes.