### PR TITLE
Reject variants with unnamed String field in enums without content attr

### DIFF
--- a/fp-bindgen/src/types/enums.rs
+++ b/fp-bindgen/src/types/enums.rs
@@ -95,7 +95,7 @@ pub(crate) fn parse_enum_item(item: ItemEnum) -> Enum {
                                     attribute",
                                 ident,
                                 variant.ident,
-                                field.ty.to_token_stream().to_string()
+                                field.ty.to_token_stream()
                             );
                         }
 


### PR DESCRIPTION
For the purposes of serialization, `String` is also a primitive, so we should reject it if it's unnamed in an enum with a `tag` attr, but no `content` attr.

Also improved the error messages a little bit.