### PR TITLE
Preserve casing by default

### DIFF
--- a/example/example-protocol/src/assets/rust_plugin_test/expected_types.rs
+++ b/example/example-protocol/src/assets/rust_plugin_test/expected_types.rs
@@ -6,7 +6,6 @@ pub type Body = serde_bytes::ByteBuf;
 pub type ComplexAlias = ComplexGuestToHost;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ComplexGuestToHost {
     pub simple: Simple,
     pub map: BTreeMap<String, Simple>,
@@ -34,19 +33,16 @@ pub struct ComplexHostToGuest {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ExplicitedlyImportedType {
     pub you_will_see_this: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GroupImportedType1 {
     pub you_will_see_this: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GroupImportedType2 {
     pub you_will_see_this: bool,
 }
@@ -65,7 +61,7 @@ pub struct HttpRequestOptions {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "PascalCase")]
 pub struct Point<T> {
     pub value: T,
 }
@@ -88,7 +84,7 @@ pub enum RequestError {
         response: Body,
     },
     /// Misc.
-    #[serde(rename = "other/misc", rename_all = "camelCase")]
+    #[serde(rename = "other/misc")]
     Other { reason: String },
 }
 
@@ -124,7 +120,6 @@ pub struct Response {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Simple {
     pub foo: i32,
     pub bar: String,
@@ -132,7 +127,6 @@ pub struct Simple {
 
 /// Tagged dynamic value.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde()]
 pub enum Value {
     Integer(i64),
     Float(f64),

--- a/example/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
+++ b/example/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
@@ -10,7 +10,6 @@ pub type Body = serde_bytes::ByteBuf;
 pub type ComplexAlias = ComplexGuestToHost;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ComplexGuestToHost {
     pub simple: Simple,
     pub map: BTreeMap<String, Simple>,
@@ -38,19 +37,16 @@ pub struct ComplexHostToGuest {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ExplicitedlyImportedType {
     pub you_will_see_this: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GroupImportedType1 {
     pub you_will_see_this: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GroupImportedType2 {
     pub you_will_see_this: bool,
 }
@@ -69,7 +65,7 @@ pub struct HttpRequestOptions {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "PascalCase")]
 pub struct Point<T> {
     pub value: T,
 }
@@ -92,12 +88,11 @@ pub enum RequestError {
         response: Body,
     },
     /// Misc.
-    #[serde(rename = "other/misc", rename_all = "camelCase")]
+    #[serde(rename = "other/misc")]
     Other { reason: String },
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Simple {
     pub foo: i32,
     pub bar: String,
@@ -105,7 +100,6 @@ pub struct Simple {
 
 /// Tagged dynamic value.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde()]
 pub enum Value {
     Integer(i64),
     Float(f64),

--- a/example/example-protocol/src/assets/ts_runtime_test/expected_types.ts
+++ b/example/example-protocol/src/assets/ts_runtime_test/expected_types.ts
@@ -35,15 +35,15 @@ export type ComplexHostToGuest = {
 };
 
 export type ExplicitedlyImportedType = {
-    youWillSeeThis: boolean;
+    you_will_see_this: boolean;
 };
 
 export type GroupImportedType1 = {
-    youWillSeeThis: boolean;
+    you_will_see_this: boolean;
 };
 
 export type GroupImportedType2 = {
-    youWillSeeThis: boolean;
+    you_will_see_this: boolean;
 };
 
 /**
@@ -68,7 +68,7 @@ export type Method =
     | "TRACE";
 
 export type Point<T> = {
-    value: T;
+    Value: T;
 };
 
 /**

--- a/example/example-protocol/src/main.rs
+++ b/example/example-protocol/src/main.rs
@@ -13,6 +13,7 @@ pub struct DeadCode {
 }
 
 #[derive(Serializable)]
+#[fp(rename_all = "PascalCase")]
 pub struct Point<T> {
     pub value: T,
 }
@@ -26,6 +27,7 @@ pub struct Simple {
 /// Multi-line doc comment with complex characters
 /// & " , \ ! '
 #[derive(Serializable)]
+#[fp(rename_all = "camelCase")]
 pub struct ComplexHostToGuest {
     pub simple: Simple,
     pub list: Vec<f64>,
@@ -73,6 +75,7 @@ pub struct RequestOptions {
 
 /// Similar to the `RequestOptions` struct, but using types from the `http` crate.
 #[derive(Clone, Debug, Serializable)]
+#[fp(rename_all = "camelCase")]
 pub struct HttpRequestOptions {
     pub url: Uri,
     pub method: Method,

--- a/fp-bindgen/src/casing.rs
+++ b/fp-bindgen/src/casing.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 pub enum Casing {
     Original,
     CamelCase,
+    PascalCase,
     SnakeCase,
     ScreamingSnakeCase,
 }
@@ -14,6 +15,7 @@ impl Casing {
         match self {
             Self::Original => None,
             Self::CamelCase => Some("camelCase"),
+            Self::PascalCase => Some("PascalCase"),
             Self::SnakeCase => Some("snake_case"),
             Self::ScreamingSnakeCase => Some("SCREAMING_SNAKE_CASE"),
         }
@@ -23,6 +25,7 @@ impl Casing {
         match self {
             Self::Original => string.to_owned(),
             Self::CamelCase => string.to_camel_case(),
+            Self::PascalCase => string.to_pascal_case(),
             Self::SnakeCase => string.to_snake_case(),
             Self::ScreamingSnakeCase => string.to_screaming_snake_case(),
         }
@@ -41,6 +44,7 @@ impl TryFrom<&str> for Casing {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "camelCase" => Ok(Self::CamelCase),
+            "PascalCase" => Ok(Self::PascalCase),
             "snake_case" => Ok(Self::SnakeCase),
             "SCREAMING_SNAKE_CASE" => Ok(Self::ScreamingSnakeCase),
             other => Err(format!("Unrecognized case format: {}", other)),

--- a/fp-bindgen/src/types/structs.rs
+++ b/fp-bindgen/src/types/structs.rs
@@ -88,9 +88,6 @@ impl StructOptions {
                 );
             }
         }
-        if opts.native_modules.is_empty() && opts.field_casing == Casing::default() {
-            opts.field_casing = Casing::CamelCase;
-        }
         opts
     }
 


### PR DESCRIPTION
This makes the behavior consistent with Serde and resolves a few internal inconsistencies.

Also added Pascal casing as an option, because why not.

To make sure this doesn't break anything, I will create two follow-up PRs:
- [x] Providers: https://github.com/fiberplane/providers/pull/35
- [x] FiberKit: https://github.com/fiberplane/studio/pull/617