### PR TITLE
HTTP HeaderMaps (de)serialize support #102

### DIFF
--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -215,7 +215,7 @@ const imports: Imports = {
       url: "https://fiberplane.dev/",
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "content-type": encoder.encode("application/json"),
       },
       body: encoder.encode(
         JSON.stringify({ "country": "🇳🇱", "type": "sign-up" }),
@@ -227,7 +227,7 @@ const imports: Imports = {
           JSON.stringify({ "status": "confirmed" }),
         ),
         headers: {
-          "Content-Type": "application/json",
+          "content-type": encoder.encode("application/json"),
         },
         status_code: 200,
       },

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -1,7 +1,7 @@
 use ::http::{Method, Uri};
 use example_bindings::*;
 use serde_bytes::ByteBuf;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap};
 use std::panic;
 use time::{macros::datetime, OffsetDateTime};
 
@@ -286,10 +286,17 @@ async fn export_async_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyR
 
 #[fp_export_impl(example_bindings)]
 async fn fetch_data(r#type: String) -> Result<String, String> {
+
+    let mut headers = ::http::HeaderMap::new();
+    headers.insert(
+        ::http::header::CONTENT_TYPE,
+        ::http::header::HeaderValue::from_static("application/json"),
+    );
+
     let result = make_http_request(Request {
         url: Uri::from_static("https://fiberplane.dev"),
         method: Method::POST,
-        headers: HashMap::from([("Content-Type".to_owned(), "application/json".to_owned())]),
+        headers,
         body: Some(ByteBuf::from(format!(
             r#"{{"country":"🇳🇱","type":"{}"}}"#,
             r#type

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_types.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, collections::HashMap, rc::Rc};
+use std::{collections::BTreeMap, rc::Rc};
 
 pub use redux_example::ReduxAction;
 pub use redux_example::StateUpdate;
@@ -143,10 +143,8 @@ pub struct Request {
     pub method: http::Method,
 
     /// HTTP headers to submit with the request.
-    ///
-    /// Note: We currently do not support the `Headers` type from the `http`
-    ///       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
-    pub headers: HashMap<String, String>,
+    #[serde(deserialize_with = "fp_bindgen_support::http::deserialize_header_map", serialize_with = "fp_bindgen_support::http::serialize_header_map")]
+    pub headers: http::HeaderMap,
 
     /// The body to submit with the request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -184,10 +182,8 @@ pub struct Response {
     pub body: Body,
 
     /// HTTP headers that were part of the response.
-    ///
-    /// Note: We currently do not support the `Headers` type from the `http`
-    ///       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
-    pub headers: HashMap<String, String>,
+    #[serde(deserialize_with = "fp_bindgen_support::http::deserialize_header_map", serialize_with = "fp_bindgen_support::http::serialize_header_map")]
+    pub headers: http::HeaderMap,
 
     /// HTTP status code.
     pub status_code: u16,

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, collections::HashMap, rc::Rc};
+use std::{collections::BTreeMap, rc::Rc};
 
 pub use redux_example::ReduxAction;
 pub use redux_example::StateUpdate;
@@ -143,10 +143,8 @@ pub struct Request {
     pub method: http::Method,
 
     /// HTTP headers to submit with the request.
-    ///
-    /// Note: We currently do not support the `Headers` type from the `http`
-    ///       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
-    pub headers: HashMap<String, String>,
+    #[serde(deserialize_with = "fp_bindgen_support::http::deserialize_header_map", serialize_with = "fp_bindgen_support::http::serialize_header_map")]
+    pub headers: http::HeaderMap,
 
     /// The body to submit with the request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -184,10 +182,8 @@ pub struct Response {
     pub body: Body,
 
     /// HTTP headers that were part of the response.
-    ///
-    /// Note: We currently do not support the `Headers` type from the `http`
-    ///       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
-    pub headers: HashMap<String, String>,
+    #[serde(deserialize_with = "fp_bindgen_support::http::deserialize_header_map", serialize_with = "fp_bindgen_support::http::serialize_header_map")]
+    pub headers: http::HeaderMap,
 
     /// HTTP status code.
     pub status_code: u16,

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_types.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_types.ts
@@ -156,11 +156,8 @@ export type Request = {
 
     /**
      * HTTP headers to submit with the request.
-     *
-     * Note: We currently do not support the `Headers` type from the `http`
-     *       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
      */
-    headers: Record<string, string>;
+    headers: HeaderMap;
 
     /**
      * The body to submit with the request.
@@ -210,11 +207,8 @@ export type Response = {
 
     /**
      * HTTP headers that were part of the response.
-     *
-     * Note: We currently do not support the `Headers` type from the `http`
-     *       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
      */
-    headers: Record<string, string>;
+    headers: HeaderMap;
 
     /**
      * HTTP status code.
@@ -287,3 +281,5 @@ export type StructWithGenerics<T> = {
     complex_nested?: Record<string, Array<FloatingPoint>>;
     optional_timestamp?: MyDateTime;
 };
+
+export type HeaderMap = { [key: string]: Uint8Array };

--- a/examples/example-protocol/src/types/http.rs
+++ b/examples/example-protocol/src/types/http.rs
@@ -1,7 +1,6 @@
 use super::Body;
 use fp_bindgen::prelude::Serializable;
 use http::{Method, Uri};
-use std::collections::HashMap;
 
 // This example shows how HTTP requests and responses could be communicated
 // while integrating the `http` crate.
@@ -16,10 +15,7 @@ pub struct Request {
     pub method: Method,
 
     /// HTTP headers to submit with the request.
-    ///
-    /// Note: We currently do not support the `Headers` type from the `http`
-    ///       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
-    pub headers: HashMap<String, String>,
+    pub headers: http::HeaderMap,
 
     /// The body to submit with the request.
     #[fp(skip_serializing_if = "Option::is_none")]
@@ -35,10 +31,7 @@ pub struct Response {
     pub body: Body,
 
     /// HTTP headers that were part of the response.
-    ///
-    /// Note: We currently do not support the `Headers` type from the `http`
-    ///       crate. See: <https://github.com/fiberplane/fp-bindgen/issues/102>
-    pub headers: HashMap<String, String>,
+    pub headers: http::HeaderMap,
 
     /// HTTP status code.
     pub status_code: u16,

--- a/examples/example-rust-runtime/src/spec/mod.rs
+++ b/examples/example-rust-runtime/src/spec/mod.rs
@@ -103,9 +103,10 @@ fn log(msg: String) {
 }
 
 async fn make_http_request(opts: Request) -> Result<Response, RequestError> {
+
     Ok(Response {
         body: ByteBuf::from(r#"status: "confirmed"#.to_string()),
-        headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
+        headers: opts.headers,
         status_code: 200,
     })
 }

--- a/examples/example-rust-runtime/src/test.rs
+++ b/examples/example-rust-runtime/src/test.rs
@@ -233,8 +233,10 @@ async fn async_struct() -> Result<()> {
 async fn fetch_async_data() -> Result<()> {
     let rt = crate::spec::bindings::Runtime::new(WASM_BYTES)?;
 
+    let response = rt.fetch_data("sign-up".to_string()).await?;
+
     assert_eq!(
-        rt.fetch_data("sign-up".to_string()).await?,
+        response,
         Ok(r#"status: "confirmed"#.to_string())
     );
     Ok(())

--- a/fp-bindgen/src/serializable/http.rs
+++ b/fp-bindgen/src/serializable/http.rs
@@ -76,6 +76,27 @@ impl Serializable for http::uri::Uri {
     }
 }
 
+impl Serializable for http::HeaderMap {
+    fn ident() -> TypeIdent {
+        TypeIdent::from("http::HeaderMap")
+    }
+
+    fn ty() -> Type {
+        Type::Custom(CustomType {
+            ident: Self::ident(),
+            rs_ty: "http::HeaderMap".to_owned(),
+            rs_dependencies: http_dependencies(),
+            serde_attrs: vec![
+                "serialize_with = \"fp_bindgen_support::http::serialize_header_map\"".to_owned(),
+                "deserialize_with = \"fp_bindgen_support::http::deserialize_header_map\""
+                    .to_owned(),
+            ],
+            ts_ty: "HeaderMap".to_owned(),
+            ts_declaration: Some(r#"{ [key: string]: Uint8Array }"#.into()),
+        })
+    }
+}
+
 fn http_dependencies() -> BTreeMap<&'static str, CargoDependency> {
     BTreeMap::from([
         (


### PR DESCRIPTION
closes #102. Converts existing `HashMap<string, string>` types to `http::HeaderMap`. 

