### PR TITLE
Build docs.rs documentation with `--all-features`

### DIFF
--- a/fp-bindgen-support/Cargo.toml
+++ b/fp-bindgen-support/Cargo.toml
@@ -9,6 +9,9 @@ authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 fp-bindgen-macros = { version = "1.0.0", path = "../macros" }
 http = { version = "0.2", optional = true }

--- a/fp-bindgen/Cargo.toml
+++ b/fp-bindgen/Cargo.toml
@@ -11,6 +11,9 @@ authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["http-compat", "rmpv-compat", "time-compat", "serde-bytes-compat"]
 http-compat = ["http"]


### PR DESCRIPTION
The docs.rs documentation for `fp-bindgen` is currently built without
all features enabled. This can be confusing, as types that are mentioned
in the README are not present in the API reference. This pull request
should take care of that, by telling docs.rs to pass `--all-features` to
`cargo doc`.

I haven't tested this, but I think it should work. The `docs.rs`
documentation on the topic seems straight-forward enough:
https://docs.rs/about/metadata

Close #120