### PR TITLE
Properly deal with generic bounds in codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,5 @@
 - Various smaller bugfixes.
 - **Deprecation**: `BindingsType::TsRuntime` is now deprecated in favor of
   `BindingsType::TsRuntimeWithExtendedConfig`.
+- Fix #88: Bounds are propagated correctly to generated types (with the exception of the compile-time only `Serializable` bound).
+- Fix #88: Deal with the Unit (`()`) type.

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -7,6 +7,7 @@ import {
 import { loadPlugin } from "./loader.ts";
 import type { Exports, Imports } from "../example-protocol/bindings/ts-runtime/index.ts";
 import type {
+  ExplicitBoundPoint,
   FpAdjacentlyTagged,
   FpFlatten,
   FpInternallyTagged,
@@ -28,6 +29,10 @@ import {Result} from "../example-protocol/bindings/ts-runtime/types.ts";
 let voidFunctionCalled = false;
 
 const imports: Imports = {
+  importExplicitBoundPoint: (arg: ExplicitBoundPoint<number>) => {
+    assertEquals(arg.value, 123);
+  },
+
   importFpAdjacentlyTagged: (arg: FpAdjacentlyTagged): FpAdjacentlyTagged => {
     assertEquals(arg, { type: "Bar", payload: "Hello, plugin!" });
     return { type: "Baz", payload: { a: -8, b: 64 } };

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -1,6 +1,9 @@
 use crate::types::*;
 
 #[fp_bindgen_support::fp_import_signature]
+pub fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>);
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_fp_adjacently_tagged(arg: FpAdjacentlyTagged) -> FpAdjacentlyTagged;
 
 #[fp_bindgen_support::fp_import_signature]

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_types.rs
@@ -31,6 +31,12 @@ pub struct DocExampleStruct {
     pub r#type: String,
 }
 
+/// A point of an arbitrary type, with an explicit 'Serializable' bound.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExplicitBoundPoint<T> {
+    pub value: T,
+}
+
 /// This struct is also not referenced by any function or data structure, but
 /// it will show up because there is an explicit `use` statement for it in the
 /// `fp_import!` macro.

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_types.rs
@@ -31,9 +31,9 @@ pub struct DocExampleStruct {
     pub r#type: String,
 }
 
-/// A point of an arbitrary type, with an explicit 'Serializable' bound.
+/// A point of an arbitrary type, with explicit trait bounds.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExplicitBoundPoint<T> {
+pub struct ExplicitBoundPoint<T: std::fmt::Debug + std::fmt::Display> {
     pub value: T,
 }
 

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -767,6 +767,7 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
     imports! {
        "fp" => {
            "__fp_host_resolve_async_value" => Function :: new_native_with_env (store , env . clone () , resolve_async_value) ,
+           "__fp_gen_import_explicit_bound_point" => Function :: new_native_with_env (store , env . clone () , _import_explicit_bound_point) ,
            "__fp_gen_import_fp_adjacently_tagged" => Function :: new_native_with_env (store , env . clone () , _import_fp_adjacently_tagged) ,
            "__fp_gen_import_fp_enum" => Function :: new_native_with_env (store , env . clone () , _import_fp_enum) ,
            "__fp_gen_import_fp_flatten" => Function :: new_native_with_env (store , env . clone () , _import_fp_flatten) ,
@@ -801,6 +802,11 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
            "__fp_gen_make_http_request" => Function :: new_native_with_env (store , env . clone () , _make_http_request) ,
         }
     }
+}
+
+pub fn _import_explicit_bound_point(env: &RuntimeInstanceData, arg: FatPtr) {
+    let arg = import_from_guest::<ExplicitBoundPoint<u64>>(env, arg);
+    let result = super::import_explicit_bound_point(arg);
 }
 
 pub fn _import_fp_adjacently_tagged(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
@@ -31,6 +31,12 @@ pub struct DocExampleStruct {
     pub r#type: String,
 }
 
+/// A point of an arbitrary type, with an explicit 'Serializable' bound.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExplicitBoundPoint<T> {
+    pub value: T,
+}
+
 /// This struct is also not referenced by any function or data structure, but
 /// it will show up because there is an explicit `use` statement for it in the
 /// `fp_import!` macro.

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_types.rs
@@ -31,9 +31,9 @@ pub struct DocExampleStruct {
     pub r#type: String,
 }
 
-/// A point of an arbitrary type, with an explicit 'Serializable' bound.
+/// A point of an arbitrary type, with explicit trait bounds.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExplicitBoundPoint<T> {
+pub struct ExplicitBoundPoint<T: std::fmt::Debug + std::fmt::Display> {
     pub value: T,
 }
 

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -11,6 +11,7 @@ import type {
     Body,
     DocExampleEnum,
     DocExampleStruct,
+    ExplicitBoundPoint,
     ExplicitedlyImportedType,
     FlattenedStruct,
     FloatingPoint,
@@ -44,6 +45,7 @@ import type {
 type FatPtr = bigint;
 
 export type Imports = {
+    importExplicitBoundPoint: (arg: ExplicitBoundPoint<number>) => void;
     importFpAdjacentlyTagged: (arg: FpAdjacentlyTagged) => FpAdjacentlyTagged;
     importFpEnum: (arg: FpVariantRenaming) => FpVariantRenaming;
     importFpFlatten: (arg: FpFlatten) => FpFlatten;
@@ -247,6 +249,10 @@ export async function createRuntime(
 
     const { instance } = await WebAssembly.instantiate(plugin, {
         fp: {
+            __fp_gen_import_explicit_bound_point: (arg_ptr: FatPtr) => {
+                const arg = parseObject<ExplicitBoundPoint<number>>(arg_ptr);
+                importFunctions.importExplicitBoundPoint(arg);
+            },
             __fp_gen_import_fp_adjacently_tagged: (arg_ptr: FatPtr): FatPtr => {
                 const arg = parseObject<FpAdjacentlyTagged>(arg_ptr);
                 return serializeObject(importFunctions.importFpAdjacentlyTagged(arg));

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_types.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_types.ts
@@ -43,6 +43,13 @@ export type DocExampleStruct = {
 };
 
 /**
+ * A point of an arbitrary type, with an explicit 'Serializable' bound.
+ */
+export type ExplicitBoundPoint<T> = {
+    value: T;
+};
+
+/**
  * This struct is also not referenced by any function or data structure, but
  * it will show up because there is an explicit `use` statement for it in the
  * `fp_import!` macro.

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_types.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_types.ts
@@ -43,7 +43,7 @@ export type DocExampleStruct = {
 };
 
 /**
- * A point of an arbitrary type, with an explicit 'Serializable' bound.
+ * A point of an arbitrary type, with explicit trait bounds.
  */
 export type ExplicitBoundPoint<T> = {
     value: T;

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -77,6 +77,7 @@ fp_import! {
     //
     // See `types/generics.rs` for more info.
     fn import_generics(arg: StructWithGenerics<u64>) -> StructWithGenerics<u64>;
+    fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>);
 
     // Passing custom types with property/variant renaming.
     //

--- a/examples/example-protocol/src/types/generics.rs
+++ b/examples/example-protocol/src/types/generics.rs
@@ -13,9 +13,9 @@ pub struct Point<T> {
     pub value: T,
 }
 
-/// A point of an arbitrary type, with an explicit 'Serializable' bound.
+/// A point of an arbitrary type, with explicit trait bounds.
 #[derive(Serializable)]
-pub struct ExplicitBoundPoint<T: Serializable> {
+pub struct ExplicitBoundPoint<T: Serializable + std::fmt::Debug + std::fmt::Display> {
     pub value: T,
 }
 

--- a/examples/example-protocol/src/types/generics.rs
+++ b/examples/example-protocol/src/types/generics.rs
@@ -13,6 +13,12 @@ pub struct Point<T> {
     pub value: T,
 }
 
+/// A point of an arbitrary type, with an explicit 'Serializable' bound.
+#[derive(Serializable)]
+pub struct ExplicitBoundPoint<T: Serializable> {
+    pub value: T,
+}
+
 #[derive(Serializable)]
 pub struct StructWithGenerics<T> {
     pub list: Vec<T>,

--- a/examples/example-rust-runtime/src/spec/mod.rs
+++ b/examples/example-rust-runtime/src/spec/mod.rs
@@ -13,6 +13,9 @@ fn import_void_function_empty_result() -> Result<(), u32> {
 }
 fn import_void_function_empty_return() -> () {}
 
+fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>) {
+    todo!()
+}
 fn import_primitive_bool(arg: bool) -> bool {
     todo!()
 }

--- a/fp-bindgen/src/generators/mod.rs
+++ b/fp-bindgen/src/generators/mod.rs
@@ -208,7 +208,7 @@ fn display_warnings(
                 .flat_map(|ty| ty.fields.iter().map(|field| &field.ty)),
         );
     warn_about_custom_serializer_usage(
-        all_idents.flat_map(|ident| ident.generic_args.iter()),
+        all_idents.flat_map(|ident| ident.generic_args.iter().map(|(arg, _)| arg)),
         "generic argument",
         types,
     );

--- a/fp-bindgen/src/generators/ts_runtime/mod.rs
+++ b/fp-bindgen/src/generators/ts_runtime/mod.rs
@@ -838,7 +838,7 @@ fn create_enum_definition(ty: &Enum, types: &TypeMap) -> String {
     format!(
         "{}export type {} =\n{};",
         join_lines(&format_docs(&ty.doc_lines), String::to_owned),
-        ty.ident,
+        ty.ident.format(false),
         variants.trim_end()
     )
 }
@@ -862,7 +862,7 @@ fn create_struct_definition(ty: &Struct, types: &TypeMap) -> String {
         format!(
             "{}export type {} = {{\n{}}}{};",
             join_lines(&format_docs(&ty.doc_lines), String::to_owned),
-            ty.ident,
+            ty.ident.format(false),
             join_lines(
                 &format_struct_fields(
                     &fields.into_iter().cloned().collect::<Vec<_>>(),
@@ -904,7 +904,7 @@ fn format_struct_fields(fields: &[Field], types: &TypeMap, casing: Casing) -> Ve
             let field_decl = match types.get(&field.ty) {
                 Some(Type::Container(name, _)) => {
                     let optional = if name == "Option" { "?" } else { "" };
-                    let arg = field
+                    let (arg, _) = field
                         .ty
                         .generic_args
                         .first()
@@ -955,7 +955,7 @@ fn format_type_with_ident(ty: &Type, ident: &TypeIdent, types: &TypeMap) -> Stri
     match ty {
         Type::Alias(name, _) => name.clone(),
         Type::Container(name, _) => {
-            let arg = ident
+            let (arg, _) = ident
                 .generic_args
                 .first()
                 .expect("Identifier was expected to contain a generic argument");
@@ -971,7 +971,7 @@ fn format_type_with_ident(ty: &Type, ident: &TypeIdent, types: &TypeMap) -> Stri
             let args: Vec<_> = ident
                 .generic_args
                 .iter()
-                .map(|arg| format_ident(arg, types))
+                .map(|(arg, _)| format_ident(arg, types))
                 .collect();
             if args.is_empty() {
                 ident.name.clone()
@@ -980,18 +980,18 @@ fn format_type_with_ident(ty: &Type, ident: &TypeIdent, types: &TypeMap) -> Stri
             }
         }
         Type::List(_, _) => {
-            let arg = ident
+            let (arg, _) = ident
                 .generic_args
                 .first()
                 .expect("Identifier was expected to contain a generic argument");
             format!("Array<{}>", format_ident(arg, types))
         }
         Type::Map(_, _, _) => {
-            let arg1 = ident
+            let (arg1, _) = ident
                 .generic_args
                 .first()
                 .expect("Identifier was expected to contain a generic argument");
-            let arg2 = ident
+            let (arg2, _) = ident
                 .generic_args
                 .get(1)
                 .expect("Identifier was expected to contain two arguments");

--- a/fp-bindgen/src/serializable/mod.rs
+++ b/fp-bindgen/src/serializable/mod.rs
@@ -44,7 +44,7 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "Box".to_owned(),
-            generic_args: vec![TypeIdent::from("T")],
+            generic_args: vec![(TypeIdent::from("T"), vec![])],
         }
     }
 
@@ -66,7 +66,10 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "BTreeMap".to_owned(),
-            generic_args: vec![TypeIdent::from("K"), TypeIdent::from("V")],
+            generic_args: vec![
+                (TypeIdent::from("K"), vec![]),
+                (TypeIdent::from("V"), vec![]),
+            ],
         }
     }
 
@@ -92,7 +95,7 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "BTreeSet".to_owned(),
-            generic_args: vec![TypeIdent::from("T")],
+            generic_args: vec![(TypeIdent::from("T"), vec![])],
         }
     }
 
@@ -114,7 +117,10 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "HashMap".to_owned(),
-            generic_args: vec![TypeIdent::from("K"), TypeIdent::from("V")],
+            generic_args: vec![
+                (TypeIdent::from("K"), vec![]),
+                (TypeIdent::from("V"), vec![]),
+            ],
         }
     }
 
@@ -140,7 +146,7 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "HashSet".to_owned(),
-            generic_args: vec![TypeIdent::from("T")],
+            generic_args: vec![(TypeIdent::from("T"), vec![])],
         }
     }
 
@@ -161,7 +167,7 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "Option".to_owned(),
-            generic_args: vec![TypeIdent::from("T")],
+            generic_args: vec![(TypeIdent::from("T"), vec![])],
         }
     }
 
@@ -182,7 +188,7 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "Rc".to_owned(),
-            generic_args: vec![TypeIdent::from("T")],
+            generic_args: vec![(TypeIdent::from("T"), vec![])],
         }
     }
 
@@ -204,7 +210,10 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "Result".to_owned(),
-            generic_args: vec![TypeIdent::from("T"), TypeIdent::from("E")],
+            generic_args: vec![
+                (TypeIdent::from("T"), vec![]),
+                (TypeIdent::from("E"), vec![]),
+            ],
         }
     }
 
@@ -267,7 +276,7 @@ where
     fn ident() -> TypeIdent {
         TypeIdent {
             name: "Vec".to_owned(),
-            generic_args: vec![TypeIdent::from("T")],
+            generic_args: vec![(TypeIdent::from("T"), vec![])],
         }
     }
 

--- a/fp-bindgen/src/types/enums.rs
+++ b/fp-bindgen/src/types/enums.rs
@@ -2,6 +2,7 @@ use super::{
     structs::{Field, Struct, StructOptions},
     Type, TypeIdent,
 };
+use crate::types::format_bounds;
 use crate::{casing::Casing, docs::get_doc_lines, primitives::Primitive, types::FieldAttrs};
 use quote::ToTokens;
 use std::{collections::BTreeMap, convert::TryFrom, str::FromStr};
@@ -26,7 +27,9 @@ pub(crate) fn parse_enum_item(item: ItemEnum) -> Enum {
             .params
             .iter()
             .filter_map(|param| match param {
-                GenericParam::Type(ty) => Some(TypeIdent::from(ty.ident.to_string())),
+                GenericParam::Type(ty) => {
+                    Some((TypeIdent::from(ty.ident.to_string()), format_bounds(ty)))
+                }
                 _ => None,
             })
             .collect(),

--- a/fp-bindgen/src/types/structs.rs
+++ b/fp-bindgen/src/types/structs.rs
@@ -1,4 +1,5 @@
 use super::TypeIdent;
+use crate::types::format_bounds;
 use crate::{casing::Casing, docs::get_doc_lines};
 use quote::ToTokens;
 use std::{collections::BTreeMap, convert::TryFrom};
@@ -23,7 +24,9 @@ pub(crate) fn parse_struct_item(item: ItemStruct) -> Struct {
             .params
             .iter()
             .filter_map(|param| match param {
-                GenericParam::Type(ty) => Some(TypeIdent::from(ty.ident.to_string())),
+                GenericParam::Type(ty) => {
+                    Some((TypeIdent::from(ty.ident.to_string()), format_bounds(ty)))
+                }
                 _ => None,
             })
             .collect(),

--- a/macros/src/serializable.rs
+++ b/macros/src/serializable.rs
@@ -1,7 +1,7 @@
 use crate::utils::{extract_path_from_type, parse_type_item};
 use proc_macro::TokenStream;
 use quote::quote;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use syn::punctuated::Punctuated;
 use syn::{Path, TypeParamBound};
 
@@ -56,7 +56,7 @@ pub(crate) fn impl_derive_serializable(item: TokenStream) -> TokenStream {
     // Remove any bounds from the generic types and store them separately.
     // Otherwise, collect_types will be called like `Foo::<T: MyTrait>::collect_types()` and where clauses
     // will be incorrect, too.
-    let mut bounds = HashMap::new();
+    let mut bounds = BTreeMap::new();
     for param in generics.type_params_mut() {
         // For every parameter we want to either extract the existing trait bounds, or, if there
         // were no existing bounds, we will mark the parameter as having no bounds.


### PR DESCRIPTION
This solves the issue mentioned in #88 where trait bounds were incorrectly suffixed with `: Serializable` even if that bound was already present. Additionally, it allows the use of other bounds whereas previously any additional bounds would cause `collect_types` to be invoked incorrectly.