### PR TITLE
Fix custom types in generic positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,7 @@
 - Fix #88: Bounds are propagated correctly to generated types (with the
   exception of the compile-time only `Serializable` bound).
 - Fix #88: Deal with the Unit (`()`) type.
-- Use `any` type in TypeScript to represent `rmpv::Value`.
-- Fix issue when TypeScript types conflicted with built-in JavaScript globals.
+- Use `any` type in TypeScript to represent `rmpv::Value` (#127).
+- Fix issue when TypeScript types conflicted with built-in JavaScript globals
+  (#128).
+- Fix custom types in generic positions (#126).

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -91,6 +91,10 @@ const imports: Imports = {
     };
   },
 
+  importGetBytes: (): Result<ArrayBuffer, string> => {
+    return { Ok: new TextEncoder().encode("Hello, world!") };
+  },
+
   importMultiplePrimitives: (arg1: number, arg2: string): bigint => {
     assertEquals(arg1, -8);
     assertEquals(arg2, "Hello, 🇳🇱!");

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -22,6 +22,9 @@ pub fn import_fp_untagged(arg: FpUntagged) -> FpUntagged;
 pub fn import_generics(arg: StructWithGenerics<u64>) -> StructWithGenerics<u64>;
 
 #[fp_bindgen_support::fp_import_signature]
+pub fn import_get_bytes() -> Result<serde_bytes::ByteBuf, String>;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_multiple_primitives(arg1: i8, arg2: String) -> i64;
 
 #[fp_bindgen_support::fp_import_signature]

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -90,7 +90,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_fp_adjacently_tagged")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_adjacently_tagged")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -114,7 +114,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_fp_enum")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_enum")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -135,7 +135,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_fp_flatten")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_flatten")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -162,7 +162,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_fp_internally_tagged")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_internally_tagged")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -186,7 +186,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_fp_struct")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_struct")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -207,7 +207,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_fp_untagged")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_untagged")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -231,7 +231,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_generics")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_generics")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -279,7 +279,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<bool as WasmAbi>::AbiType), <bool as WasmAbi>::AbiType>(
+            .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_bool",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -299,7 +299,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<f32 as WasmAbi>::AbiType), <f32 as WasmAbi>::AbiType>(
+            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_f32",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -319,7 +319,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<f64 as WasmAbi>::AbiType), <f64 as WasmAbi>::AbiType>(
+            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_f64",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -339,7 +339,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<i16 as WasmAbi>::AbiType), <i16 as WasmAbi>::AbiType>(
+            .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i16",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -359,7 +359,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<i32 as WasmAbi>::AbiType), <i32 as WasmAbi>::AbiType>(
+            .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i32",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -379,7 +379,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<i64 as WasmAbi>::AbiType), <i64 as WasmAbi>::AbiType>(
+            .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i64",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -399,7 +399,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<i8 as WasmAbi>::AbiType), <i8 as WasmAbi>::AbiType>(
+            .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i8",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -419,7 +419,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<u16 as WasmAbi>::AbiType), <u16 as WasmAbi>::AbiType>(
+            .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u16",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -439,7 +439,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<u32 as WasmAbi>::AbiType), <u32 as WasmAbi>::AbiType>(
+            .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u32",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -459,7 +459,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<u64 as WasmAbi>::AbiType), <u64 as WasmAbi>::AbiType>(
+            .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u64",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -479,7 +479,7 @@ impl Runtime {
         env.init_with_instance(&instance).unwrap();
         let function = instance
             .exports
-            .get_native_function::<(<u8 as WasmAbi>::AbiType), <u8 as WasmAbi>::AbiType>(
+            .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u8",
             )
             .map_err(|_| InvocationError::FunctionNotExported)?;
@@ -508,7 +508,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_serde_adjacently_tagged")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_adjacently_tagged")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -532,7 +532,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_serde_enum")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_enum")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -553,7 +553,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_serde_flatten")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_flatten")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -580,7 +580,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_serde_internally_tagged")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_internally_tagged")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -604,7 +604,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_serde_struct")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_struct")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -628,7 +628,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_serde_untagged")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_untagged")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -649,7 +649,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_string")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_string")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -670,7 +670,7 @@ impl Runtime {
         let arg = export_to_guest_raw(&env, arg);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_export_timestamp")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_timestamp")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -714,7 +714,7 @@ impl Runtime {
         let r#type = export_to_guest_raw(&env, r#type);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_fetch_data")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_fetch_data")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(r#type.to_abi())?;
         let result = ModuleRawFuture::new(env.clone(), result).await;
@@ -755,7 +755,7 @@ impl Runtime {
         let action = export_to_guest_raw(&env, action);
         let function = instance
             .exports
-            .get_native_function::<(FatPtr), FatPtr>("__fp_gen_reducer_bridge")
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_reducer_bridge")
             .map_err(|_| InvocationError::FunctionNotExported)?;
         let result = function.call(action.to_abi())?;
         let result = import_from_guest_raw(&env, result);
@@ -774,6 +774,7 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
            "__fp_gen_import_fp_struct" => Function :: new_native_with_env (store , env . clone () , _import_fp_struct) ,
            "__fp_gen_import_fp_untagged" => Function :: new_native_with_env (store , env . clone () , _import_fp_untagged) ,
            "__fp_gen_import_generics" => Function :: new_native_with_env (store , env . clone () , _import_generics) ,
+           "__fp_gen_import_get_bytes" => Function :: new_native_with_env (store , env . clone () , _import_get_bytes) ,
            "__fp_gen_import_multiple_primitives" => Function :: new_native_with_env (store , env . clone () , _import_multiple_primitives) ,
            "__fp_gen_import_primitive_bool" => Function :: new_native_with_env (store , env . clone () , _import_primitive_bool) ,
            "__fp_gen_import_primitive_f32" => Function :: new_native_with_env (store , env . clone () , _import_primitive_f32) ,
@@ -842,6 +843,11 @@ pub fn _import_fp_untagged(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
 pub fn _import_generics(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
     let arg = import_from_guest::<StructWithGenerics<u64>>(env, arg);
     let result = super::import_generics(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_get_bytes(env: &RuntimeInstanceData) -> FatPtr {
+    let result = super::import_get_bytes();
     export_to_guest(env, &result)
 }
 

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -51,6 +51,7 @@ export type Imports = {
     importFpStruct: (arg: FpPropertyRenaming) => FpPropertyRenaming;
     importFpUntagged: (arg: FpUntagged) => FpUntagged;
     importGenerics: (arg: StructWithGenerics<number>) => StructWithGenerics<number>;
+    importGetBytes: () => Result<ArrayBuffer, string>;
     importMultiplePrimitives: (arg1: number, arg2: string) => bigint;
     importPrimitiveBool: (arg: boolean) => boolean;
     importPrimitiveF32: (arg: number) => number;
@@ -274,6 +275,9 @@ export async function createRuntime(
             __fp_gen_import_generics: (arg_ptr: FatPtr): FatPtr => {
                 const arg = parseObject<StructWithGenerics<number>>(arg_ptr);
                 return serializeObject(importFunctions.importGenerics(arg));
+            },
+            __fp_gen_import_get_bytes: (): FatPtr => {
+                return serializeObject(importFunctions.importGetBytes());
             },
             __fp_gen_import_multiple_primitives: (arg1: number, arg2_ptr: FatPtr): bigint => {
                 const arg2 = parseObject<string>(arg2_ptr);

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -3,6 +3,7 @@
 use fp_bindgen::{prelude::*, types::CargoDependency};
 use once_cell::sync::Lazy;
 use redux_example::{ReduxAction, StateUpdate};
+use serde_bytes::ByteBuf;
 use std::collections::{BTreeMap, BTreeSet};
 
 // Referencing types using their full module path can be problematic in some
@@ -77,6 +78,9 @@ fp_import! {
     //
     // See `types/generics.rs` for more info.
     fn import_generics(arg: StructWithGenerics<u64>) -> StructWithGenerics<u64>;
+
+    // Custom type in a generic position.
+    fn import_get_bytes() -> Result<ByteBuf, String>;
 
     // Passing custom types with property/variant renaming.
     //

--- a/examples/example-rust-runtime/src/spec/mod.rs
+++ b/examples/example-rust-runtime/src/spec/mod.rs
@@ -70,6 +70,10 @@ fn import_generics(arg: StructWithGenerics<u64>) -> StructWithGenerics<u64> {
     todo!()
 }
 
+fn import_get_bytes() -> Result<serde_bytes::ByteBuf, String> {
+    todo!()
+}
+
 fn import_fp_struct(arg: FpPropertyRenaming) -> FpPropertyRenaming {
     todo!()
 }

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -227,32 +227,36 @@ fn format_ident(ident: &TypeIdent, types: &TypeMap) -> String {
 }
 
 fn format_type_with_ident(ty: &Type, ident: &TypeIdent, types: &TypeMap) -> String {
+    let format_name_with_args = |name: &str, maybe_num_expected_args: Option<usize>| {
+        let generic_args: Vec<_> = ident
+            .generic_args
+            .iter()
+            .map(|arg| format_ident(arg, types))
+            .collect();
+        if let Some(num_expected_args) = maybe_num_expected_args {
+            if generic_args.len() != num_expected_args {
+                panic!(
+                    "Expected {} generic arguments, but found {}",
+                    num_expected_args,
+                    generic_args.len()
+                );
+            }
+        }
+
+        if generic_args.is_empty() {
+            name.to_owned()
+        } else {
+            format!("{}<{}>", name, generic_args.join(", "))
+        }
+    };
+
     match ty {
         Type::Alias(name, _) => name.clone(),
-        Type::Container(name, _) | Type::List(name, _) => {
-            let arg = ident
-                .generic_args
-                .first()
-                .expect("Identifier was expected to contain a generic argument");
-            format!("{}<{}>", name, format_ident(arg, types))
-        }
+        Type::Container(name, _) | Type::List(name, _) => format_name_with_args(name, Some(1)),
         Type::Custom(custom) => custom.rs_ty.clone(),
-        Type::Map(name, _, _) => {
-            let arg1 = ident
-                .generic_args
-                .first()
-                .expect("Identifier was expected to contain a generic argument");
-            let arg2 = ident
-                .generic_args
-                .get(1)
-                .expect("Identifier was expected to contain two arguments");
-            format!(
-                "{}<{}, {}>",
-                name,
-                format_ident(arg1, types),
-                format_ident(arg2, types)
-            )
-        }
+        Type::Enum(Enum { ident, .. }) => format_name_with_args(&ident.name, None),
+        Type::Map(name, _, _) => format_name_with_args(name, Some(2)),
+        Type::Struct(Struct { ident, .. }) => format_name_with_args(&ident.name, None),
         Type::Tuple(items) => format!(
             "[{}]",
             items


### PR DESCRIPTION
If custom types were used in generic positions (such as `Result<ByteBuf, ...>`), the identifier wasn't using the proper formatting, which could result in their Rust formatting not being specified.

Also removed unnecessary parentheses in the Wasmer runtime bindings for functions that only have a single argument. This prevents a bunch of compiler warnings.