### PR TITLE
Support for primitive arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Add support for arrays of primitives (#94).
+
 ## 2.0.1
 
 - Fix custom types in generic positions in export function signatures (#130).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## main
 
 - Add support for arrays of primitives (#94).
 

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -160,6 +160,46 @@ const imports: Imports = {
     return 8;
   },
 
+  importArrayU8: (arg: Uint8Array): Uint8Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Uint8Array([1, 2, 3]);
+  },
+
+  importArrayU16: (arg: Uint16Array): Uint16Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Uint16Array([1, 2, 3]);
+  },
+
+  importArrayU32: (arg: Uint32Array): Uint32Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Uint32Array([1, 2, 3]);
+  },
+
+  importArrayI8: (arg: Int8Array): Int8Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Int8Array([1, 2, 3]);
+  },
+
+  importArrayI16: (arg: Int16Array): Int16Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Int16Array([1, 2, 3]);
+  },
+
+  importArrayI32: (arg: Int32Array): Int32Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Int32Array([1, 2, 3]);
+  },
+
+  importArrayF32: (arg: Float32Array): Float32Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Float32Array([1, 2, 3]);
+  },
+
+  importArrayF64: (arg: Float64Array): Float64Array => {
+    assertEquals(arg, [1, 2, 3]);
+    return new Float64Array([1, 2, 3]);
+  },
+
   importSerdeAdjacentlyTagged: (
     arg: SerdeAdjacentlyTagged,
   ): SerdeAdjacentlyTagged => {
@@ -289,6 +329,19 @@ Deno.test("primitives", async () => {
 
   assertAlmostEquals(plugin.exportPrimitiveF32?.(3.1415926535) ?? 0, 3.1415926535);
   assertAlmostEquals(plugin.exportPrimitiveF64?.(2.718281828459) ?? 0, 2.718281828459);
+});
+
+Deno.test("arrays", async () => {
+  const plugin = await loadExamplePlugin();
+
+  assertEquals(plugin.exportArrayU8?.(new Uint8Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayU16?.(new Uint16Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayU32?.(new Uint32Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayI8?.(new Int8Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayI16?.(new Int16Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayI32?.(new Int32Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayF32?.(new Float32Array([1, 2, 3])), [1, 2, 3]);
+  assertEquals(plugin.exportArrayF64?.(new Float64Array([1, 2, 3])), [1, 2, 3]);
 });
 
 Deno.test("string", async () => {

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -91,6 +91,54 @@ fn export_primitive_u64(arg: u64) -> u64 {
 }
 
 #[fp_export_impl(example_bindings)]
+fn export_array_u8(arg: [u8; 3]) -> [u8; 3] {
+    assert_eq!(arg, [1u8, 2u8, 3u8]);
+    [1u8, 2u8, 3u8]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_u16(arg: [u16; 3]) -> [u16; 3] {
+    assert_eq!(arg, [1u16, 2u16, 3u16]);
+    [1u16, 2u16, 3u16]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_u32(arg: [u32; 3]) -> [u32; 3] {
+    assert_eq!(arg, [1u32, 2u32, 3u32]);
+    [1u32, 2u32, 3u32]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_i8(arg: [i8; 3]) -> [i8; 3] {
+    assert_eq!(arg, [1i8, 2i8, 3i8]);
+    [1i8, 2i8, 3i8]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_i16(arg: [i16; 3]) -> [i16; 3] {
+    assert_eq!(arg, [1i16, 2i16, 3i16]);
+    [1i16, 2i16, 3i16]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_i32(arg: [i32; 3]) -> [i32; 3] {
+    assert_eq!(arg, [1i32, 2i32, 3i32]);
+    [1i32, 2i32, 3i32]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_f32(arg: [f32; 3]) -> [f32; 3] {
+    assert_eq!(arg, [1.0f32, 2.0f32, 3.0f32]);
+    [1.0f32, 2.0f32, 3.0f32]
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_array_f64(arg: [f64; 3]) -> [f64; 3] {
+    assert_eq!(arg, [1.0f64, 2.0f64, 3.0f64]);
+    [1.0f64, 2.0f64, 3.0f64]
+}
+
+#[fp_export_impl(example_bindings)]
 fn export_string(arg: String) -> String {
     assert_eq!(arg, "Hello, plugin!");
     "Hello, world!".to_owned()

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
@@ -1,6 +1,30 @@
 use crate::types::*;
 
 #[fp_bindgen_support::fp_export_signature]
+pub fn export_array_f32(arg: [f32; 3]) -> [f32; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_f64(arg: [f64; 3]) -> [f64; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_i16(arg: [i16; 3]) -> [i16; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_i32(arg: [i32; 3]) -> [i32; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_i8(arg: [i8; 3]) -> [i8; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_u16(arg: [u16; 3]) -> [u16; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_u32(arg: [u32; 3]) -> [u32; 3];
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_array_u8(arg: [u8; 3]) -> [u8; 3];
+
+#[fp_bindgen_support::fp_export_signature]
 pub async fn export_async_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming;
 
 #[fp_bindgen_support::fp_export_signature]

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -1,7 +1,28 @@
 use crate::types::*;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_array_u8(arg: [u8; 16]) -> [u8; 16];
+pub fn import_array_f32(arg: [f32; 3]) -> [f32; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_f64(arg: [f64; 3]) -> [f64; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_i16(arg: [i16; 3]) -> [i16; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_i32(arg: [i32; 3]) -> [i32; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_i8(arg: [i8; 3]) -> [i8; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_u16(arg: [u16; 3]) -> [u16; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_u32(arg: [u32; 3]) -> [u32; 3];
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_array_u8(arg: [u8; 3]) -> [u8; 3];
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>);

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -1,6 +1,9 @@
 use crate::types::*;
 
 #[fp_bindgen_support::fp_import_signature]
+pub fn import_array_u8(arg: [u8; 16]) -> [u8; 16];
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>);
 
 #[fp_bindgen_support::fp_import_signature]

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -38,6 +38,190 @@ impl Runtime {
         Store::new(&engine)
     }
 
+    pub fn export_array_f32(&self, arg: [f32; 3]) -> Result<[f32; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_f32_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_f32_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_f32")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_f32".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_f64(&self, arg: [f64; 3]) -> Result<[f64; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_f64_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_f64_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_f64")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_f64".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_i16(&self, arg: [i16; 3]) -> Result<[i16; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_i16_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_i16_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_i16")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_i16".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_i32(&self, arg: [i32; 3]) -> Result<[i32; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_i32_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_i32_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_i32")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_i32".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_i8(&self, arg: [i8; 3]) -> Result<[i8; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_i8_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_i8_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_i8")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_i8".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_u16(&self, arg: [u16; 3]) -> Result<[u16; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_u16_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_u16_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_u16")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_u16".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_u32(&self, arg: [u32; 3]) -> Result<[u32; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_u32_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_u32_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_u32")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_u32".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
+    pub fn export_array_u8(&self, arg: [u8; 3]) -> Result<[u8; 3], InvocationError> {
+        let arg = serialize_to_vec(&arg);
+        let result = self.export_array_u8_raw(arg);
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub fn export_array_u8_raw(&self, arg: Vec<u8>) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let arg = export_to_guest_raw(&env, arg);
+        let function = instance
+            .exports
+            .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_array_u8")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_array_u8".to_owned())
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = import_from_guest_raw(&env, result);
+        Ok(result)
+    }
+
     pub async fn export_async_struct(
         &self,
         arg1: FpPropertyRenaming,
@@ -64,7 +248,9 @@ impl Runtime {
             .get_native_function::<(FatPtr, <u64 as WasmAbi>::AbiType), FatPtr>(
                 "__fp_gen_export_async_struct",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_async_struct".to_owned())
+            })?;
         let result = function.call(arg1.to_abi(), arg2.to_abi())?;
         let result = ModuleRawFuture::new(env.clone(), result).await;
         Ok(result)
@@ -91,7 +277,11 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_adjacently_tagged")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_fp_adjacently_tagged".to_owned(),
+                )
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -115,7 +305,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_enum")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_fp_enum".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -136,7 +328,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_flatten")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_fp_flatten".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -163,7 +357,11 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_internally_tagged")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_fp_internally_tagged".to_owned(),
+                )
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -187,7 +385,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_struct")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_fp_struct".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -208,7 +408,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_fp_untagged")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_fp_untagged".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -232,7 +434,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_generics")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_generics".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -253,7 +457,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<(), FatPtr>("__fp_gen_export_get_bytes")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_get_bytes".to_owned())
+            })?;
         let result = function.call()?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -283,7 +489,11 @@ impl Runtime {
             .get_native_function::<(<i8 as WasmAbi>::AbiType, FatPtr), <i64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_multiple_primitives",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_multiple_primitives".to_owned(),
+                )
+            })?;
         let result = function.call(arg1.to_abi(), arg2.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -303,7 +513,9 @@ impl Runtime {
             .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_bool",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_bool".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -323,7 +535,9 @@ impl Runtime {
             .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_f32",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_f32".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -343,7 +557,9 @@ impl Runtime {
             .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_f64",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_f64".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -363,7 +579,9 @@ impl Runtime {
             .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i16",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i16".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -383,7 +601,9 @@ impl Runtime {
             .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i32",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i32".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -403,7 +623,9 @@ impl Runtime {
             .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i64",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i64".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -423,7 +645,9 @@ impl Runtime {
             .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_i8",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i8".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -443,7 +667,9 @@ impl Runtime {
             .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u16",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u16".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -463,7 +689,9 @@ impl Runtime {
             .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u32",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u32".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -483,7 +711,9 @@ impl Runtime {
             .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u64",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u64".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -503,7 +733,9 @@ impl Runtime {
             .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
                 "__fp_gen_export_primitive_u8",
             )
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u8".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -530,7 +762,11 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_adjacently_tagged")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_serde_adjacently_tagged".to_owned(),
+                )
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -554,7 +790,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_enum")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_serde_enum".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -575,7 +813,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_flatten")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_serde_flatten".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -602,7 +842,11 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_internally_tagged")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_serde_internally_tagged".to_owned(),
+                )
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -626,7 +870,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_struct")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_serde_struct".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -650,7 +896,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_serde_untagged")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_serde_untagged".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -671,7 +919,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_string")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_string".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -692,7 +942,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_export_timestamp")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_timestamp".to_owned())
+            })?;
         let result = function.call(arg.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -710,7 +962,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<(), ()>("__fp_gen_export_void_function")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_export_void_function".to_owned())
+            })?;
         let result = function.call()?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -736,7 +990,7 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_fetch_data")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| InvocationError::FunctionNotExported("__fp_gen_fetch_data".to_owned()))?;
         let result = function.call(r#type.to_abi())?;
         let result = ModuleRawFuture::new(env.clone(), result).await;
         Ok(result)
@@ -755,7 +1009,7 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<(), ()>("__fp_gen_init")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| InvocationError::FunctionNotExported("__fp_gen_init".to_owned()))?;
         let result = function.call()?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
@@ -777,7 +1031,9 @@ impl Runtime {
         let function = instance
             .exports
             .get_native_function::<FatPtr, FatPtr>("__fp_gen_reducer_bridge")
-            .map_err(|_| InvocationError::FunctionNotExported)?;
+            .map_err(|_| {
+                InvocationError::FunctionNotExported("__fp_gen_reducer_bridge".to_owned())
+            })?;
         let result = function.call(action.to_abi())?;
         let result = import_from_guest_raw(&env, result);
         Ok(result)
@@ -788,6 +1044,13 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
     imports! {
         "fp" => {
             "__fp_host_resolve_async_value" => Function::new_native_with_env(store, env.clone(), resolve_async_value),
+            "__fp_gen_import_array_f32" => Function::new_native_with_env(store, env.clone(), _import_array_f32),
+            "__fp_gen_import_array_f64" => Function::new_native_with_env(store, env.clone(), _import_array_f64),
+            "__fp_gen_import_array_i16" => Function::new_native_with_env(store, env.clone(), _import_array_i16),
+            "__fp_gen_import_array_i32" => Function::new_native_with_env(store, env.clone(), _import_array_i32),
+            "__fp_gen_import_array_i8" => Function::new_native_with_env(store, env.clone(), _import_array_i8),
+            "__fp_gen_import_array_u16" => Function::new_native_with_env(store, env.clone(), _import_array_u16),
+            "__fp_gen_import_array_u32" => Function::new_native_with_env(store, env.clone(), _import_array_u32),
             "__fp_gen_import_array_u8" => Function::new_native_with_env(store, env.clone(), _import_array_u8),
             "__fp_gen_import_explicit_bound_point" => Function::new_native_with_env(store, env.clone(), _import_explicit_bound_point),
             "__fp_gen_import_fp_adjacently_tagged" => Function::new_native_with_env(store, env.clone(), _import_fp_adjacently_tagged),
@@ -827,8 +1090,50 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
     }
 }
 
+pub fn _import_array_f32(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[f32; 3]>(env, arg);
+    let result = super::import_array_f32(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_array_f64(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[f64; 3]>(env, arg);
+    let result = super::import_array_f64(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_array_i16(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[i16; 3]>(env, arg);
+    let result = super::import_array_i16(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_array_i32(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[i32; 3]>(env, arg);
+    let result = super::import_array_i32(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_array_i8(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[i8; 3]>(env, arg);
+    let result = super::import_array_i8(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_array_u16(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[u16; 3]>(env, arg);
+    let result = super::import_array_u16(arg);
+    export_to_guest(env, &result)
+}
+
+pub fn _import_array_u32(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[u32; 3]>(env, arg);
+    let result = super::import_array_u32(arg);
+    export_to_guest(env, &result)
+}
+
 pub fn _import_array_u8(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
-    let arg = import_from_guest::<[u8; 16]>(env, arg);
+    let arg = import_from_guest::<[u8; 3]>(env, arg);
     let result = super::import_array_u8(arg);
     export_to_guest(env, &result)
 }

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -788,6 +788,7 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
     imports! {
         "fp" => {
             "__fp_host_resolve_async_value" => Function::new_native_with_env(store, env.clone(), resolve_async_value),
+            "__fp_gen_import_array_u8" => Function::new_native_with_env(store, env.clone(), _import_array_u8),
             "__fp_gen_import_explicit_bound_point" => Function::new_native_with_env(store, env.clone(), _import_explicit_bound_point),
             "__fp_gen_import_fp_adjacently_tagged" => Function::new_native_with_env(store, env.clone(), _import_fp_adjacently_tagged),
             "__fp_gen_import_fp_enum" => Function::new_native_with_env(store, env.clone(), _import_fp_enum),
@@ -824,6 +825,12 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
             "__fp_gen_make_http_request" => Function::new_native_with_env(store, env.clone(), _make_http_request),
         }
     }
+}
+
+pub fn _import_array_u8(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {
+    let arg = import_from_guest::<[u8; 16]>(env, arg);
+    let result = super::import_array_u8(arg);
+    export_to_guest(env, &result)
 }
 
 pub fn _import_explicit_bound_point(env: &RuntimeInstanceData, arg: FatPtr) {

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -12,6 +12,13 @@ import type * as types from "./types.ts";
 type FatPtr = bigint;
 
 export type Imports = {
+    importArrayF32: (arg: Float32Array) => Float32Array;
+    importArrayF64: (arg: Float64Array) => Float64Array;
+    importArrayI16: (arg: Int16Array) => Int16Array;
+    importArrayI32: (arg: Int32Array) => Int32Array;
+    importArrayI8: (arg: Int8Array) => Int8Array;
+    importArrayU16: (arg: Uint16Array) => Uint16Array;
+    importArrayU32: (arg: Uint32Array) => Uint32Array;
     importArrayU8: (arg: Uint8Array) => Uint8Array;
     importExplicitBoundPoint: (arg: types.ExplicitBoundPoint<number>) => void;
     importFpAdjacentlyTagged: (arg: types.FpAdjacentlyTagged) => types.FpAdjacentlyTagged;
@@ -50,6 +57,14 @@ export type Imports = {
 };
 
 export type Exports = {
+    exportArrayF32?: (arg: Float32Array) => Float32Array;
+    exportArrayF64?: (arg: Float64Array) => Float64Array;
+    exportArrayI16?: (arg: Int16Array) => Int16Array;
+    exportArrayI32?: (arg: Int32Array) => Int32Array;
+    exportArrayI8?: (arg: Int8Array) => Int8Array;
+    exportArrayU16?: (arg: Uint16Array) => Uint16Array;
+    exportArrayU32?: (arg: Uint32Array) => Uint32Array;
+    exportArrayU8?: (arg: Uint8Array) => Uint8Array;
     exportAsyncStruct?: (arg1: types.FpPropertyRenaming, arg2: bigint) => Promise<types.FpPropertyRenaming>;
     exportFpAdjacentlyTagged?: (arg: types.FpAdjacentlyTagged) => types.FpAdjacentlyTagged;
     exportFpEnum?: (arg: types.FpVariantRenaming) => types.FpVariantRenaming;
@@ -83,6 +98,14 @@ export type Exports = {
     fetchData?: (rType: string) => Promise<types.Result<string, string>>;
     init?: () => void;
     reducerBridge?: (action: types.ReduxAction) => types.StateUpdate;
+    exportArrayF32Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayF64Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayI16Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayI32Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayI8Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayU16Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayU32Raw?: (arg: Uint8Array) => Uint8Array;
+    exportArrayU8Raw?: (arg: Uint8Array) => Uint8Array;
     exportAsyncStructRaw?: (arg1: Uint8Array, arg2: bigint) => Promise<Uint8Array>;
     exportFpAdjacentlyTaggedRaw?: (arg: Uint8Array) => Uint8Array;
     exportFpEnumRaw?: (arg: Uint8Array) => Uint8Array;
@@ -220,6 +243,34 @@ export async function createRuntime(
 
     const { instance } = await WebAssembly.instantiate(plugin, {
         fp: {
+            __fp_gen_import_array_f32: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Float32Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayF32(arg));
+            },
+            __fp_gen_import_array_f64: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Float64Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayF64(arg));
+            },
+            __fp_gen_import_array_i16: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Int16Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayI16(arg));
+            },
+            __fp_gen_import_array_i32: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Int32Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayI32(arg));
+            },
+            __fp_gen_import_array_i8: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Int8Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayI8(arg));
+            },
+            __fp_gen_import_array_u16: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Uint16Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayU16(arg));
+            },
+            __fp_gen_import_array_u32: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Uint32Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayU32(arg));
+            },
             __fp_gen_import_array_u8: (arg_ptr: FatPtr): FatPtr => {
                 const arg = parseObject<Uint8Array>(arg_ptr);
                 return serializeObject(importFunctions.importArrayU8(arg));
@@ -374,6 +425,78 @@ export async function createRuntime(
     const resolveFuture = getExport<(asyncValuePtr: FatPtr, resultPtr: FatPtr) => void>("__fp_guest_resolve_async_value");
 
     return {
+        exportArrayF32: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_f32 as any;
+            if (!export_fn) return;
+
+            return (arg: Float32Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Float32Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayF64: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_f64 as any;
+            if (!export_fn) return;
+
+            return (arg: Float64Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Float64Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayI16: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_i16 as any;
+            if (!export_fn) return;
+
+            return (arg: Int16Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Int16Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayI32: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_i32 as any;
+            if (!export_fn) return;
+
+            return (arg: Int32Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Int32Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayI8: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_i8 as any;
+            if (!export_fn) return;
+
+            return (arg: Int8Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Int8Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayU16: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_u16 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint16Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Uint16Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayU32: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_u32 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint32Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Uint32Array>(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayU8: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_u8 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = serializeObject(arg);
+                return parseObject<Uint8Array>(export_fn(arg_ptr));
+            };
+        })(),
         exportAsyncStruct: (() => {
             const export_fn = instance.exports.__fp_gen_export_async_struct as any;
             if (!export_fn) return;
@@ -587,6 +710,78 @@ export async function createRuntime(
             return (action: types.ReduxAction) => {
                 const action_ptr = serializeObject(action);
                 return parseObject<types.StateUpdate>(export_fn(action_ptr));
+            };
+        })(),
+        exportArrayF32Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_f32 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayF64Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_f64 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayI16Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_i16 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayI32Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_i32 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayI8Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_i8 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayU16Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_u16 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayU32Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_u32 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
+            };
+        })(),
+        exportArrayU8Raw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_array_u8 as any;
+            if (!export_fn) return;
+
+            return (arg: Uint8Array) => {
+                const arg_ptr = exportToMemory(arg);
+                return importFromMemory(export_fn(arg_ptr));
             };
         })(),
         exportAsyncStructRaw: (() => {

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -430,7 +430,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Float32Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Float32Array>(export_fn(arg_ptr));
             };
         })(),
@@ -439,7 +439,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Float64Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Float64Array>(export_fn(arg_ptr));
             };
         })(),
@@ -448,7 +448,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Int16Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Int16Array>(export_fn(arg_ptr));
             };
         })(),
@@ -457,7 +457,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Int32Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Int32Array>(export_fn(arg_ptr));
             };
         })(),
@@ -466,7 +466,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Int8Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Int8Array>(export_fn(arg_ptr));
             };
         })(),
@@ -475,7 +475,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Uint16Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Uint16Array>(export_fn(arg_ptr));
             };
         })(),
@@ -484,7 +484,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Uint32Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Uint32Array>(export_fn(arg_ptr));
             };
         })(),
@@ -493,7 +493,7 @@ export async function createRuntime(
             if (!export_fn) return;
 
             return (arg: Uint8Array) => {
-                const arg_ptr = serializeObject(arg);
+                const arg_ptr = serializeObject(Array.from(arg));
                 return parseObject<Uint8Array>(export_fn(arg_ptr));
             };
         })(),

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -12,6 +12,7 @@ import type * as types from "./types.ts";
 type FatPtr = bigint;
 
 export type Imports = {
+    importArrayU8: (arg: Uint8Array) => Uint8Array;
     importExplicitBoundPoint: (arg: types.ExplicitBoundPoint<number>) => void;
     importFpAdjacentlyTagged: (arg: types.FpAdjacentlyTagged) => types.FpAdjacentlyTagged;
     importFpEnum: (arg: types.FpVariantRenaming) => types.FpVariantRenaming;
@@ -219,6 +220,10 @@ export async function createRuntime(
 
     const { instance } = await WebAssembly.instantiate(plugin, {
         fp: {
+            __fp_gen_import_array_u8: (arg_ptr: FatPtr): FatPtr => {
+                const arg = parseObject<Uint8Array>(arg_ptr);
+                return serializeObject(importFunctions.importArrayU8(arg));
+            },
             __fp_gen_import_explicit_bound_point: (arg_ptr: FatPtr) => {
                 const arg = parseObject<types.ExplicitBoundPoint<number>>(arg_ptr);
                 importFunctions.importExplicitBoundPoint(arg);

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -59,6 +59,9 @@ fp_import! {
     fn import_primitive_u32(arg: u32) -> u32;
     fn import_primitive_u64(arg: u64) -> u64;
 
+    // Passing arrays:
+    fn import_array_u8(arg: [u8; 16]) -> [u8; 16];
+
     // Passing strings:
     fn import_string(arg: String) -> String;
 

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -60,7 +60,14 @@ fp_import! {
     fn import_primitive_u64(arg: u64) -> u64;
 
     // Passing arrays:
-    fn import_array_u8(arg: [u8; 16]) -> [u8; 16];
+    fn import_array_u8(arg: [u8; 3]) -> [u8; 3];
+    fn import_array_u16(arg: [u16; 3]) -> [u16; 3];
+    fn import_array_u32(arg: [u32; 3]) -> [u32; 3];
+    fn import_array_i8(arg: [i8; 3]) -> [i8; 3];
+    fn import_array_i16(arg: [i16; 3]) -> [i16; 3];
+    fn import_array_i32(arg: [i32; 3]) -> [i32; 3];
+    fn import_array_f32(arg: [f32; 3]) -> [f32; 3];
+    fn import_array_f64(arg: [f64; 3]) -> [f64; 3];
 
     // Passing strings:
     fn import_string(arg: String) -> String;
@@ -136,6 +143,16 @@ fp_export! {
     fn export_primitive_u16(arg: u16) -> u16;
     fn export_primitive_u32(arg: u32) -> u32;
     fn export_primitive_u64(arg: u64) -> u64;
+
+    // Passing arrays:
+    fn export_array_u8(arg: [u8; 3]) -> [u8; 3];
+    fn export_array_u16(arg: [u16; 3]) -> [u16; 3];
+    fn export_array_u32(arg: [u32; 3]) -> [u32; 3];
+    fn export_array_i8(arg: [i8; 3]) -> [i8; 3];
+    fn export_array_i16(arg: [i16; 3]) -> [i16; 3];
+    fn export_array_i32(arg: [i32; 3]) -> [i32; 3];
+    fn export_array_f32(arg: [f32; 3]) -> [f32; 3];
+    fn export_array_f64(arg: [f64; 3]) -> [f64; 3];
 
     // Passing strings:
     fn export_string(arg: String) -> String;

--- a/examples/example-rust-runtime/src/spec/mod.rs
+++ b/examples/example-rust-runtime/src/spec/mod.rs
@@ -50,6 +50,31 @@ fn import_primitive_u64(arg: u64) -> u64 {
     todo!()
 }
 
+fn import_array_u8(arg: [u8; 3]) -> [u8; 3] {
+    todo!()
+}
+fn import_array_u16(arg: [u16; 3]) -> [u16; 3] {
+    todo!()
+}
+fn import_array_u32(arg: [u32; 3]) -> [u32; 3] {
+    todo!()
+}
+fn import_array_i8(arg: [i8; 3]) -> [i8; 3] {
+    todo!()
+}
+fn import_array_i16(arg: [i16; 3]) -> [i16; 3] {
+    todo!()
+}
+fn import_array_i32(arg: [i32; 3]) -> [i32; 3] {
+    todo!()
+}
+fn import_array_f32(arg: [f32; 3]) -> [f32; 3] {
+    todo!()
+}
+fn import_array_f64(arg: [f64; 3]) -> [f64; 3] {
+    todo!()
+}
+
 fn import_string(arg: String) -> String {
     todo!()
 }

--- a/examples/example-rust-runtime/src/test.rs
+++ b/examples/example-rust-runtime/src/test.rs
@@ -38,6 +38,21 @@ fn primitives() -> Result<()> {
 }
 
 #[test]
+fn arrays() -> Result<()> {
+    let rt = crate::spec::bindings::Runtime::new(WASM_BYTES)?;
+
+    assert_eq!(rt.export_array_u8([1u8, 2u8, 3u8])?, [1u8, 2u8, 3u8]);
+    assert_eq!(rt.export_array_u16([1u16, 2u16, 3u16])?, [1u16, 2u16, 3u16]);
+    assert_eq!(rt.export_array_u32([1u32, 2u32, 3u32])?, [1u32, 2u32, 3u32]);
+    assert_eq!(rt.export_array_i8([1i8, 2i8, 3i8])?, [1i8, 2i8, 3i8]);
+    assert_eq!(rt.export_array_i16([1i16, 2i16, 3i16])?, [1i16, 2i16, 3i16]);
+    assert_eq!(rt.export_array_i32([1i32, 2i32, 3i32])?, [1i32, 2i32, 3i32]);
+    assert_eq!(rt.export_array_f32([1f32, 2f32, 3f32])?, [1f32, 2f32, 3f32]);
+    assert_eq!(rt.export_array_f64([1f64, 2f64, 3f64])?, [1f64, 2f64, 3f64]);
+    Ok(())
+}
+
+#[test]
 fn string() -> Result<()> {
     let rt = crate::spec::bindings::Runtime::new(WASM_BYTES)?;
 

--- a/fp-bindgen-support/src/host/errors.rs
+++ b/fp-bindgen-support/src/host/errors.rs
@@ -8,8 +8,8 @@ pub enum RuntimeError {
 
 #[derive(Debug, Error)]
 pub enum InvocationError {
-    #[error("expected function was not exported")]
-    FunctionNotExported,
+    #[error("expected function was not exported: {0}")]
+    FunctionNotExported(String),
 
     #[error("returned data did not match expected type")]
     UnexpectedReturnType,

--- a/fp-bindgen/src/functions.rs
+++ b/fp-bindgen/src/functions.rs
@@ -67,8 +67,9 @@ impl Function {
                 ),
                 FnArg::Typed(arg) => FunctionArg {
                     name: arg.pat.to_token_stream().to_string(),
-                    ty: TypeIdent::try_from(arg.ty.as_ref())
-                        .unwrap_or_else(|_| panic!("Invalid argument type for function {}", name)),
+                    ty: TypeIdent::try_from(arg.ty.as_ref()).unwrap_or_else(|e| {
+                        panic!("Invalid argument type for function {}: {}", name, e)
+                    }),
                 },
             })
             .collect();

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -202,8 +202,8 @@ pub fn format_modifiers(function: &Function) -> String {
     if function.is_async { "async " } else { "" }.to_owned()
 }
 
-fn format_functions(export_functions: FunctionList, types: &TypeMap, macro_path: &str) -> String {
-    export_functions
+fn format_functions(functions: FunctionList, types: &TypeMap, macro_path: &str) -> String {
+    functions
         .iter()
         .map(|func| {
             let name = &func.name;

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -166,7 +166,7 @@ pub {modifiers}fn {name}_raw(&self{raw_args}) -> Result<{raw_return_type}, Invoc
     {serialize_raw_args}let function = instance
         .exports
         .get_native_function::<{wasm_args}, {wasm_return_type}>("__fp_gen_{name}")
-        .map_err(|_| InvocationError::FunctionNotExported)?;
+        .map_err(|_| InvocationError::FunctionNotExported("__fp_gen_{name}".to_owned()))?;
     let result = function.call({wasm_arg_names})?;
     {raw_return_wrapper}Ok(result)
 }}"#

--- a/fp-bindgen/src/primitives.rs
+++ b/fp-bindgen/src/primitives.rs
@@ -47,8 +47,9 @@ impl Primitive {
             I32 => Some("Int32Array"),
             F32 => Some("Float32Array"),
             F64 => Some("Float64Array"),
-            _ => None
-        }.map(|s| s.to_owned())
+            _ => None,
+        }
+        .map(|s| s.to_owned())
     }
 }
 

--- a/fp-bindgen/src/primitives.rs
+++ b/fp-bindgen/src/primitives.rs
@@ -35,6 +35,21 @@ impl Primitive {
         };
         string.to_owned()
     }
+
+    pub fn js_array_name(&self) -> Option<String> {
+        use Primitive::*;
+        match self {
+            U8 => Some("Uint8Array"),
+            U16 => Some("Uint16Array"),
+            U32 => Some("Uint32Array"),
+            I8 => Some("Int8Array"),
+            I16 => Some("Int16Array"),
+            I32 => Some("Int32Array"),
+            F32 => Some("Float32Array"),
+            F64 => Some("Float64Array"),
+            _ => None
+        }.map(|s| s.to_owned())
+    }
 }
 
 impl FromStr for Primitive {

--- a/fp-bindgen/src/serializable/mod.rs
+++ b/fp-bindgen/src/serializable/mod.rs
@@ -45,7 +45,7 @@ where
         TypeIdent {
             name: "Box".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -71,7 +71,7 @@ where
                 (TypeIdent::from("K"), vec![]),
                 (TypeIdent::from("V"), vec![]),
             ],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -98,7 +98,7 @@ where
         TypeIdent {
             name: "BTreeSet".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -124,7 +124,7 @@ where
                 (TypeIdent::from("K"), vec![]),
                 (TypeIdent::from("V"), vec![]),
             ],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -151,7 +151,7 @@ where
         TypeIdent {
             name: "HashSet".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -173,7 +173,7 @@ where
         TypeIdent {
             name: "Option".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -195,7 +195,7 @@ where
         TypeIdent {
             name: "Rc".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -221,7 +221,7 @@ where
                 (TypeIdent::from("T"), vec![]),
                 (TypeIdent::from("E"), vec![]),
             ],
-            array_len: 0,
+            ..Default::default()
         }
     }
 
@@ -285,7 +285,7 @@ where
         TypeIdent {
             name: "Vec".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
-            array_len: 0,
+            ..Default::default()
         }
     }
 

--- a/fp-bindgen/src/serializable/mod.rs
+++ b/fp-bindgen/src/serializable/mod.rs
@@ -45,6 +45,7 @@ where
         TypeIdent {
             name: "Box".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
+            array_len: 0,
         }
     }
 
@@ -70,6 +71,7 @@ where
                 (TypeIdent::from("K"), vec![]),
                 (TypeIdent::from("V"), vec![]),
             ],
+            array_len: 0,
         }
     }
 
@@ -96,6 +98,7 @@ where
         TypeIdent {
             name: "BTreeSet".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
+            array_len: 0,
         }
     }
 
@@ -121,6 +124,7 @@ where
                 (TypeIdent::from("K"), vec![]),
                 (TypeIdent::from("V"), vec![]),
             ],
+            array_len: 0,
         }
     }
 
@@ -147,6 +151,7 @@ where
         TypeIdent {
             name: "HashSet".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
+            array_len: 0,
         }
     }
 
@@ -168,6 +173,7 @@ where
         TypeIdent {
             name: "Option".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
+            array_len: 0,
         }
     }
 
@@ -189,6 +195,7 @@ where
         TypeIdent {
             name: "Rc".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
+            array_len: 0,
         }
     }
 
@@ -214,6 +221,7 @@ where
                 (TypeIdent::from("T"), vec![]),
                 (TypeIdent::from("E"), vec![]),
             ],
+            array_len: 0,
         }
     }
 
@@ -277,6 +285,7 @@ where
         TypeIdent {
             name: "Vec".to_owned(),
             generic_args: vec![(TypeIdent::from("T"), vec![])],
+            array_len: 0,
         }
     }
 

--- a/fp-bindgen/src/types/enums.rs
+++ b/fp-bindgen/src/types/enums.rs
@@ -33,6 +33,7 @@ pub(crate) fn parse_enum_item(item: ItemEnum) -> Enum {
                 _ => None,
             })
             .collect(),
+        array_len: 0,
     };
     let options = EnumOptions::from_attrs(&item.attrs);
     let variants = item

--- a/fp-bindgen/src/types/enums.rs
+++ b/fp-bindgen/src/types/enums.rs
@@ -33,7 +33,7 @@ pub(crate) fn parse_enum_item(item: ItemEnum) -> Enum {
                 _ => None,
             })
             .collect(),
-        array_len: 0,
+        ..Default::default()
     };
     let options = EnumOptions::from_attrs(&item.attrs);
     let variants = item

--- a/fp-bindgen/src/types/mod.rs
+++ b/fp-bindgen/src/types/mod.rs
@@ -19,6 +19,7 @@ pub type TypeMap = BTreeMap<TypeIdent, Type>;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Type {
     Alias(String, TypeIdent),
+    Array(Primitive, usize),
     Container(String, TypeIdent),
     Custom(CustomType),
     Enum(Enum),
@@ -47,6 +48,7 @@ impl Type {
     pub fn name(&self) -> String {
         match self {
             Self::Alias(name, _) => name.clone(),
+            Self::Array(primitive, size) => format!("[{}; {}]", primitive.name(), size),
             Self::Container(name, ident) => format!("{}<{}>", name, ident),
             Self::Custom(custom) => custom.ident.to_string(),
             Self::Enum(Enum { ident, .. }) => ident.to_string(),

--- a/fp-bindgen/src/types/structs.rs
+++ b/fp-bindgen/src/types/structs.rs
@@ -30,6 +30,7 @@ pub(crate) fn parse_struct_item(item: ItemStruct) -> Struct {
                 _ => None,
             })
             .collect(),
+        array_len: 0,
     };
     let fields = item
         .fields

--- a/fp-bindgen/src/types/structs.rs
+++ b/fp-bindgen/src/types/structs.rs
@@ -30,7 +30,7 @@ pub(crate) fn parse_struct_item(item: ItemStruct) -> Struct {
                 _ => None,
             })
             .collect(),
-        array_len: 0,
+        ..Default::default()
     };
     let fields = item
         .fields

--- a/fp-bindgen/src/types/type_ident.rs
+++ b/fp-bindgen/src/types/type_ident.rs
@@ -19,6 +19,10 @@ impl TypeIdent {
         }
     }
 
+    pub fn is_array(&self) -> bool {
+        self.array_len > 0
+    }
+
     pub fn is_primitive(&self) -> bool {
         self.as_primitive().is_some()
     }
@@ -78,7 +82,8 @@ impl Display for TypeIdent {
 
 impl From<&str> for TypeIdent {
     fn from(name: &str) -> Self {
-        Self::from_str(name).unwrap_or_else(|_| panic!("Could not convert '{}' into a TypeIdent", name))
+        Self::from_str(name)
+            .unwrap_or_else(|_| panic!("Could not convert '{}' into a TypeIdent", name))
     }
 }
 
@@ -92,14 +97,19 @@ impl FromStr for TypeIdent {
                 .strip_prefix('[')
                 .and_then(|s| s.strip_suffix(']'))
                 .ok_or(format!("Invalid array syntax in: {}", string))?
-                .split(';').collect::<Vec<_>>();
+                .split(';')
+                .collect::<Vec<_>>();
 
             let element = split[0].trim();
-            let len = usize::from_str(split[1].trim()).map_err(|_| format!("Invalid array length in: {}", string))?;
+            let len = usize::from_str(split[1].trim())
+                .map_err(|_| format!("Invalid array length in: {}", string))?;
 
             let primitive = Primitive::from_str(element)?;
             if primitive.js_array_name().is_none() {
-                return Err(format!("Only arrays of primitives supported by Javascript are allowed, found: {}", string));
+                return Err(format!(
+                    "Only arrays of primitives supported by Javascript are allowed, found: {}",
+                    string
+                ));
             }
 
             (element, len)

--- a/fp-bindgen/src/types/type_ident.rs
+++ b/fp-bindgen/src/types/type_ident.rs
@@ -355,7 +355,7 @@ mod tests {
         let t = TypeIdent::from_str("[u32; 8]").unwrap();
         assert_eq!(t.name, "u32");
         assert!(t.generic_args.is_empty());
-        assert_eq!(t.array_len, 8);
+        assert_eq!(t.array, NonZeroUsize::new(8));
 
         // Cannot create non-primitive arrays, and other error scenarios
         assert!(TypeIdent::from_str("[Vec<f32>; 8]").is_err());

--- a/fp-bindgen/src/types/type_ident.rs
+++ b/fp-bindgen/src/types/type_ident.rs
@@ -1,6 +1,6 @@
 use crate::primitives::Primitive;
-use std::{convert::TryFrom, fmt::Display, str::FromStr};
 use std::num::NonZeroUsize;
+use std::{convert::TryFrom, fmt::Display, str::FromStr};
 use syn::{PathArguments, TypeParamBound, TypePath, TypeTuple};
 
 #[derive(Clone, Default, Debug, Eq, Hash, PartialEq)]
@@ -70,7 +70,7 @@ impl TypeIdent {
 
         match self.array {
             Some(len) => format!("[{}; {}]", ty, len),
-            None => ty
+            None => ty,
         }
     }
 }

--- a/macros/src/primitives.rs
+++ b/macros/src/primitives.rs
@@ -38,6 +38,16 @@ impl Primitive {
                     Type::Primitive(Primitive::#self)
                 }
             }
+
+            impl<const N: usize> Serializable for [#ty; N] {
+                fn ident() -> TypeIdent {
+                    TypeIdent::from(format!("[{}; {}]", #ty_str, N).as_str())
+                }
+
+                fn ty() -> Type {
+                    Type::Array(Primitive::#self, N)
+                }
+            }
         };
         implementation.into()
     }

--- a/macros/src/serializable.rs
+++ b/macros/src/serializable.rs
@@ -1,15 +1,16 @@
 use crate::utils::{extract_path_from_type, parse_type_item};
+use crate::CollectableTypeDefinition;
 use proc_macro::TokenStream;
 use quote::quote;
 use std::collections::{BTreeMap, HashSet};
 use syn::punctuated::Punctuated;
-use syn::{Path, TypeParamBound};
+use syn::TypeParamBound;
 
 pub(crate) fn impl_derive_serializable(item: TokenStream) -> TokenStream {
     let item_str = item.to_string();
     let (item_name, item, mut generics) = parse_type_item(item);
 
-    let field_types: HashSet<Path> = match item {
+    let field_types: HashSet<CollectableTypeDefinition> = match item {
         syn::Item::Enum(ty) => ty
             .variants
             .into_iter()

--- a/macros/src/typing.rs
+++ b/macros/src/typing.rs
@@ -24,6 +24,7 @@ pub(crate) fn is_ret_type_complex(output: &ReturnType) -> bool {
 
 pub(crate) fn is_type_complex(ty: &Type) -> bool {
     match ty {
+        Type::Array(_) => true,
         Type::Path(tp) if tp.qself.is_none() => {
             let name = tp.path.to_token_stream().to_string();
             !matches!(


### PR DESCRIPTION
Closes #94.

This change introduces support for primitive arrays, using TypedArrays on the JS side.