### PR TITLE
Derive Clone for Runtime

### DIFF
--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -13,6 +13,7 @@ use fp_bindgen_support::{
 };
 use wasmer::{imports, Function, ImportObject, Instance, Module, Store, WasmerEnv};
 
+#[derive(Clone)]
 pub struct Runtime {
     module: Module,
 }

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -13,6 +13,7 @@ use fp_bindgen_support::{
 };
 use wasmer::{imports, Function, ImportObject, Instance, Module, Store, WasmerEnv};
 
+#[derive(Clone)]
 pub struct Runtime {
     module: Module,
 }

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -339,6 +339,7 @@ use fp_bindgen_support::{{
 }};
 use wasmer::{{imports, Function, ImportObject, Instance, Module, Store, WasmerEnv}};
 
+#[derive(Clone)]
 pub struct Runtime {{
     module: Module,
 }}


### PR DESCRIPTION
The Wasmer `Module` that the `Runtime` wraps implements `Clone` so the `Runtime` should too. This allows us to compile the wasm code once and clone the `Runtime` to handle multiple requests.
