### PR TITLE
Now that Rust 1.64.0 is out we don't need nightly anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,17 +55,9 @@ jobs:
           cargo run
           popd
 
-#     TODO: remove the following step as soon as the file
-#      examples/example-plugin/rust-toolchain.toml will have been removed
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly
-
-#     TODO: remove the line adding targets to the nightly toolchain as soon as the file
-#      examples/example-plugin/rust-toolchain.toml will have been removed
       - name: Install Wasm target
         run: |
           rustup target add wasm32-unknown-unknown wasm32-wasi
-          rustup target add wasm32-unknown-unknown wasm32-wasi --toolchain nightly
 
       - name: Verify example-plugin builds
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install latest stable compiler
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy
+
       - name: Cache multiple paths
         id: cache
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-${{ hashFiles('**/*.lock') }}
+          key: ${{ runner.os }}-${{ rustc_hash }}-${{ hashFiles('**/*.lock') }}
 
       - name: Clean cache if it's too big
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install latest stable compiler
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -32,7 +33,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-${{ rustc_hash }}-${{ hashFiles('**/*.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/*.lock') }}
 
       - name: Clean cache if it's too big
         run: |

--- a/examples/example-plugin/rust-toolchain.toml
+++ b/examples/example-plugin/rust-toolchain.toml
@@ -1,7 +1,0 @@
-# This file changes the channel of the toolchain used for compiling this crate.
-# Currently, we need the nightly channel in order to specify multiple targets in
-# [build].target in .cargo/config. This feature will be available in stable soon
-# though. As soon as it is available this file can be deleted.
-# The issue is tracked here: https://github.com/rust-lang/cargo/issues/8176
-[toolchain]
-channel = "nightly"


### PR DESCRIPTION
c36797991dd35b0d60aa4c16866d60d9d280febe introduced the need for a nightly compiler because certain crates needed to be compiled for multiple targets. Rust 1.64.0 now supports this in stable as well, so we don't need nightly anymore.