### PR TITLE
Support workspace dependencies

### DIFF
--- a/fp-bindgen/src/serializable/http.rs
+++ b/fp-bindgen/src/serializable/http.rs
@@ -102,8 +102,7 @@ fn http_dependencies() -> BTreeMap<&'static str, CargoDependency> {
         (
             "fp-bindgen-support",
             CargoDependency {
-                git: Some("ssh://git@github.com/fiberplane/fp-bindgen.git"),
-                branch: Some("main"),
+                version: Some(env!("CARGO_PKG_VERSION")),
                 features: BTreeSet::from(["http"]),
                 ..Default::default()
             },

--- a/fp-bindgen/src/serializable/http.rs
+++ b/fp-bindgen/src/serializable/http.rs
@@ -104,10 +104,8 @@ fn http_dependencies() -> BTreeMap<&'static str, CargoDependency> {
             CargoDependency {
                 git: Some("ssh://git@github.com/fiberplane/fp-bindgen.git"),
                 branch: Some("main"),
-                path: None,
-                version: None,
                 features: BTreeSet::from(["http"]),
-                default_features: None,
+                ..Default::default()
             },
         ),
         ("http", CargoDependency::with_version("0.2")),

--- a/fp-bindgen/src/serializable/rmpv.rs
+++ b/fp-bindgen/src/serializable/rmpv.rs
@@ -16,10 +16,7 @@ impl Serializable for rmpv::Value {
                 CargoDependency {
                     version: Some("1.0"),
                     features: BTreeSet::from(["with-serde"]),
-                    git: None,
-                    branch: None,
-                    path: None,
-                    default_features: None,
+                    ..Default::default()
                 },
             )]),
             serde_attrs: Vec::new(),

--- a/fp-bindgen/src/serializable/time.rs
+++ b/fp-bindgen/src/serializable/time.rs
@@ -14,12 +14,9 @@ impl Serializable for time::OffsetDateTime {
             rs_dependencies: BTreeMap::from([(
                 "time",
                 CargoDependency {
-                    branch: None,
-                    git: None,
-                    path: None,
                     version: Some("0.3"),
                     features: BTreeSet::from(["serde-well-known"]),
-                    default_features: None,
+                    ..Default::default()
                 },
             )]),
             serde_attrs: vec![r#"with = "time::serde::rfc3339""#.to_owned()],
@@ -41,12 +38,9 @@ impl Serializable for time::PrimitiveDateTime {
             rs_dependencies: BTreeMap::from([(
                 "time",
                 CargoDependency {
-                    branch: None,
-                    git: None,
-                    path: None,
                     version: Some("0.3"),
                     features: BTreeSet::from(["serde-well-known"]),
-                    default_features: None,
+                    ..Default::default()
                 },
             )]),
             serde_attrs: vec![r#"with = "time::serde::rfc3339""#.to_owned()],

--- a/fp-bindgen/src/types/cargo_dependency.rs
+++ b/fp-bindgen/src/types/cargo_dependency.rs
@@ -93,6 +93,8 @@ impl fmt::Display for CargoDependency {
             if let Some(branch) = self.branch {
                 attributes.push(format!("branch = {}", quote_value(branch)));
             }
+        } else if self.workspace == Some(true) {
+            attributes.push("workspace = true".to_owned());
         }
 
         if let Some(version) = self.version {

--- a/fp-bindgen/src/types/cargo_dependency.rs
+++ b/fp-bindgen/src/types/cargo_dependency.rs
@@ -42,10 +42,10 @@ impl CargoDependency {
         } else if let Some(workspace) = &other.workspace {
             Self {
                 workspace: Some(*workspace),
-                git: None,
-                branch: None,
-                path: None,
-                version: None,
+                git: other.git,
+                branch: other.branch,
+                path: other.path,
+                version: other.version,
                 features: self.features.union(&other.features).copied().collect(),
                 default_features: other.default_features.or(self.default_features),
             }

--- a/fp-bindgen/src/types/cargo_dependency.rs
+++ b/fp-bindgen/src/types/cargo_dependency.rs
@@ -9,6 +9,7 @@ pub struct CargoDependency {
     pub version: Option<&'static str>,
     pub features: BTreeSet<&'static str>,
     pub default_features: Option<bool>,
+    pub workspace: Option<bool>,
 }
 
 impl CargoDependency {
@@ -23,6 +24,7 @@ impl CargoDependency {
                 git: None,
                 branch: None,
                 path: Some(path),
+                workspace: None,
                 version: other.version.or(self.version),
                 features: self.features.union(&other.features).copied().collect(),
                 default_features: other.default_features.or(self.default_features),
@@ -32,7 +34,18 @@ impl CargoDependency {
                 git: Some(git),
                 branch: other.branch,
                 path: None,
+                workspace: None,
                 version: other.version.or(self.version),
+                features: self.features.union(&other.features).copied().collect(),
+                default_features: other.default_features.or(self.default_features),
+            }
+        } else if let Some(workspace) = &other.workspace {
+            Self {
+                workspace: Some(*workspace),
+                git: None,
+                branch: None,
+                path: None,
+                version: None,
                 features: self.features.union(&other.features).copied().collect(),
                 default_features: other.default_features.or(self.default_features),
             }
@@ -41,6 +54,7 @@ impl CargoDependency {
                 git: self.git,
                 branch: self.branch,
                 path: self.path,
+                workspace: self.workspace,
                 version: other.version.or(self.version),
                 features: self.features.union(&other.features).copied().collect(),
                 default_features: other.default_features.or(self.default_features),
@@ -63,6 +77,7 @@ impl CargoDependency {
             version: Some(version),
             features,
             default_features: None,
+            workspace: None,
         }
     }
 }


### PR DESCRIPTION
Adds support for [workspace dependences](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace), which were added in Rust 1.64.
