### PR TITLE
Fix xtask wasmer path

### DIFF
--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -57,7 +57,7 @@ pub fn test() -> TaskResult<()> {
     )?;
 
     progress.next_step(TEST, "Running end-to-end wasmer tests...");
-    run(cargo(&["test"]).dir(from_root("examples/example-rust-runtime")))?;
+    run(cargo(&["test"]).dir(from_root("examples/example-rust-wasmer-runtime")))?;
 
     Ok(())
 }


### PR DESCRIPTION
The wasmer runtime path was not updated, causing `xtask test` to fail.