### PR TITLE
Add async stress tests

### DIFF
--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -362,6 +362,17 @@ async fn fetch_data(r#type: String) -> Result<String, String> {
 }
 
 #[fp_export_impl(example_bindings)]
+async fn delay(succeed: bool, delay_ms: u64) -> Result<(), ()> {
+    perform_async_delay(succeed, delay_ms).await?;
+
+    if succeed {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+#[fp_export_impl(example_bindings)]
 fn export_get_bytes() -> Result<Bytes, String> {
     import_get_bytes().map(|bytes| {
         let mut new_bytes = BytesMut::with_capacity(bytes.len() + 7);

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
@@ -1,5 +1,9 @@
 use crate::types::*;
 
+/// Delay for a specific amount of time and then succeed or fail.
+#[fp_bindgen_support::fp_export_signature]
+pub async fn delay(succeed: bool, delay_ms: u64) -> Result<(), ()>;
+
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_array_f32(arg: [f32; 3]) -> [f32; 3];
 

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -132,3 +132,7 @@ pub fn log(message: String);
 /// See `types/http.rs` for more info.
 #[fp_bindgen_support::fp_import_signature]
 pub async fn make_http_request(request: Request) -> HttpResult;
+
+/// Example how an async delay (or any async task) can be exposed to plugins.
+#[fp_bindgen_support::fp_import_signature]
+pub async fn perform_async_delay(succeed: bool, delay_ms: u64) -> Result<(), ()>;

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -26,9 +26,40 @@ impl Runtime {
     }
 
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer::Singlepass::default();
+        let compiler = wasmer::Cranelift::default();
         let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
+    }
+
+    /// Delay for a specific amount of time and then succeed or fail.
+    pub async fn delay(
+        &self,
+        succeed: bool,
+        delay_ms: u64,
+    ) -> Result<Result<(), ()>, InvocationError> {
+        let result = self.delay_raw(succeed, delay_ms);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn delay_raw(
+        &self,
+        succeed: bool,
+        delay_ms: u64,
+    ) -> Result<Vec<u8>, InvocationError> {
+        let mut env = RuntimeInstanceData::default();
+        let import_object = create_import_object(self.module.store(), &env);
+        let instance = Instance::new(&self.module, &import_object).unwrap();
+        env.init_with_instance(&instance).unwrap();
+        let function = instance
+            .exports
+            .get_native_function::<(<bool as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType), FatPtr>(
+                "__fp_gen_delay",
+            )
+            .map_err(|_| InvocationError::FunctionNotExported("__fp_gen_delay".to_owned()))?;
+        let result = function.call(succeed.to_abi(), delay_ms.to_abi())?;
+        let result = ModuleRawFuture::new(env.clone(), result).await;
+        Ok(result)
     }
 
     pub fn export_array_f32(&self, arg: [f32; 3]) -> Result<[f32; 3], InvocationError> {
@@ -1101,6 +1132,7 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
             "__fp_gen_import_void_function_empty_return" => Function::new_native_with_env(store, env.clone(), _import_void_function_empty_return),
             "__fp_gen_log" => Function::new_native_with_env(store, env.clone(), _log),
             "__fp_gen_make_http_request" => Function::new_native_with_env(store, env.clone(), _make_http_request),
+            "__fp_gen_perform_async_delay" => Function::new_native_with_env(store, env.clone(), _perform_async_delay),
         }
     }
 }
@@ -1389,6 +1421,25 @@ pub fn _log(env: &RuntimeInstanceData, message: FatPtr) {
 pub fn _make_http_request(env: &RuntimeInstanceData, request: FatPtr) -> FatPtr {
     let request = import_from_guest::<Request>(env, request);
     let result = super::make_http_request(request);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
+pub fn _perform_async_delay(
+    env: &RuntimeInstanceData,
+    succeed: <bool as WasmAbi>::AbiType,
+    delay_ms: <u64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let succeed = WasmAbi::from_abi(succeed);
+    let delay_ms = WasmAbi::from_abi(delay_ms);
+    let result = super::perform_async_delay(succeed, delay_ms);
     let env = env.clone();
     let async_ptr = create_future_value(&env);
     let handle = tokio::runtime::Handle::current();

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -55,9 +55,11 @@ export type Imports = {
     importVoidFunctionEmptyReturn: () => void;
     log: (message: string) => void;
     makeHttpRequest: (request: types.Request) => Promise<types.HttpResult>;
+    performAsyncDelay: (succeed: boolean, delayMs: bigint) => Promise<types.Result<void, void>>;
 };
 
 export type Exports = {
+    delay?: (succeed: boolean, delayMs: bigint) => Promise<types.Result<void, void>>;
     exportArrayF32?: (arg: Float32Array) => Float32Array;
     exportArrayF64?: (arg: Float64Array) => Float64Array;
     exportArrayI16?: (arg: Int16Array) => Int16Array;
@@ -100,6 +102,7 @@ export type Exports = {
     fetchData?: (rType: string) => Promise<types.Result<string, string>>;
     init?: () => void;
     reducerBridge?: (action: types.ReduxAction) => types.StateUpdate;
+    delayRaw?: (succeed: boolean, delayMs: bigint) => Promise<Uint8Array>;
     exportArrayF32Raw?: (arg: Uint8Array) => Uint8Array;
     exportArrayF64Raw?: (arg: Uint8Array) => Uint8Array;
     exportArrayI16Raw?: (arg: Uint8Array) => Uint8Array;
@@ -418,6 +421,20 @@ export async function createRuntime(
                     });
                 return _async_result_ptr;
             },
+            __fp_gen_perform_async_delay: (succeed: boolean, delayMs: bigint): FatPtr => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.performAsyncDelay(succeed, delayMs)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "perform_async_delay"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_host_resolve_async_value: resolvePromise,
         },
     });
@@ -436,6 +453,12 @@ export async function createRuntime(
     const resolveFuture = getExport<(asyncValuePtr: FatPtr, resultPtr: FatPtr) => void>("__fp_guest_resolve_async_value");
 
     return {
+        delay: (() => {
+            const export_fn = instance.exports.__fp_gen_delay as any;
+            if (!export_fn) return;
+
+            return (succeed: boolean, delayMs: bigint) => promiseFromPtr(export_fn(succeed, delayMs)).then((ptr) => parseObject<types.Result<void, void>>(ptr));
+        })(),
         exportArrayF32: (() => {
             const export_fn = instance.exports.__fp_gen_export_array_f32 as any;
             if (!export_fn) return;
@@ -728,6 +751,12 @@ export async function createRuntime(
                 const action_ptr = serializeObject(action);
                 return parseObject<types.StateUpdate>(export_fn(action_ptr));
             };
+        })(),
+        delayRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_delay as any;
+            if (!export_fn) return;
+
+            return (succeed: boolean, delayMs: bigint) => promiseFromPtr(export_fn(succeed, delayMs)).then(importFromMemory);
         })(),
         exportArrayF32Raw: (() => {
             const export_fn = instance.exports.__fp_gen_export_array_f32 as any;

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -123,6 +123,9 @@ fp_import! {
     ///
     /// See `types/http.rs` for more info.
     async fn make_http_request(request: Request) -> HttpResult;
+
+    /// Example how an async delay (or any async task) can be exposed to plugins.
+    async fn perform_async_delay(succeed: bool, delay_ms: u64) -> Result<(), ()>;
 }
 
 fp_export! {
@@ -203,6 +206,9 @@ fp_export! {
 
     /// Example how plugin could expose async data-fetching capabilities.
     async fn fetch_data(r#type: String) -> Result<String, String>;
+
+    /// Delay for a specific amount of time and then succeed or fail.
+    async fn delay(succeed: bool, delay_ms: u64) -> Result<(), ()>;
 
     /// Called on the plugin to give it a chance to initialize.
     fn init();

--- a/examples/example-rust-wasmer-runtime/Cargo.toml
+++ b/examples/example-rust-wasmer-runtime/Cargo.toml
@@ -23,7 +23,7 @@ time = { version = "0.3", features = [
   "serde-well-known",
   "macros",
 ] }
-tokio = { version = "1.9.0", features = ["rt", "macros"] }
+tokio = { version = "1.9.0", features = ["rt", "macros", "time"] }
 wasmer = { version = "2.3", default-features = false, features = ["singlepass", "default-engine"] }
 wasmer-wasi = "2.3"
 anyhow = "1.0"

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -1,6 +1,7 @@
 pub mod bindings;
 pub mod types;
 
+use std::time::Duration;
 use bytes::Bytes;
 use serde_bytes::ByteBuf;
 use types::*;
@@ -145,4 +146,14 @@ async fn make_http_request(opts: Request) -> Result<Response, RequestError> {
         headers: opts.headers,
         status_code: 200,
     })
+}
+
+async fn perform_async_delay(succeed: bool, delay_ms: u64) -> Result<(), ()> {
+    let _ = tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+
+    if succeed {
+        Ok(())
+    } else {
+        Err(())
+    }
 }

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -265,6 +265,26 @@ async fn fetch_async_data() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn concurrent_delays() -> Result<()> {
+    let rt = Runtime::new(WASM_BYTES)?;
+
+    let responses = tokio::join!(
+        rt.delay(true, 120),
+        rt.delay(true, 90),
+        rt.delay(false, 75),
+        rt.delay(true, 60),
+        rt.delay(true, 30),
+    );
+    assert_eq!(responses.0.ok().unwrap(), Ok(()));
+    assert_eq!(responses.1.ok().unwrap(), Ok(()));
+    assert_eq!(responses.2.ok().unwrap(), Err(()));
+    assert_eq!(responses.3.ok().unwrap(), Ok(()));
+    assert_eq!(responses.4.ok().unwrap(), Ok(()));
+
+    Ok(())
+}
+
 #[test]
 fn bytes() -> Result<()> {
     let rt = Runtime::new(WASM_BYTES)?;

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -352,7 +352,7 @@ impl Runtime {{
     }}
 
     fn default_store() -> wasmer::Store {{
-        let compiler = wasmer::Singlepass::default();
+        let compiler = wasmer::Cranelift::default();
         let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }}

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -52,9 +52,7 @@ pub fn test() -> TaskResult<()> {
     run(cargo(&["build"]).dir(from_root("examples/example-plugin")))?;
 
     progress.next_step(TEST, "Running Cargo tests...");
-    run(
-        cargo(&["test"])
-    )?;
+    run(cargo(&["test"]))?;
 
     progress.next_step(TEST, "Running deno tests...");
     run(

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -51,6 +51,11 @@ pub fn test() -> TaskResult<()> {
     progress.next_step(TRUCK, "Building example plugin...");
     run(cargo(&["build"]).dir(from_root("examples/example-plugin")))?;
 
+    progress.next_step(TEST, "Running Cargo tests...");
+    run(
+        cargo(&["test"])
+    )?;
+
     progress.next_step(TEST, "Running deno tests...");
     run(
         deno(&["test", "--allow-read", "tests.ts"]).dir(from_root("examples/example-deno-runtime"))


### PR DESCRIPTION
Some async stress tests. Seem to be succeeding, which is nice, but not really helping to debug any potential issues with waker race conditions.