### PR TITLE
Revert "Only use singlepass compiler (#139)", since this doesn't work yet on M1

### DIFF
--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -25,9 +25,17 @@ impl Runtime {
         Ok(Self { module })
     }
 
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer::Singlepass::default();
-        let engine = wasmer::Universal::new(compiler).engine();
+        let compiler = wasmer_compiler_cranelift::Cranelift::default();
+        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        Store::new(&engine)
+    }
+
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+    fn default_store() -> wasmer::Store {
+        let compiler = wasmer_compiler_singlepass::Singlepass::default();
+        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
         Store::new(&engine)
     }
 

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -25,9 +25,17 @@ impl Runtime {
         Ok(Self { module })
     }
 
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer::Singlepass::default();
-        let engine = wasmer::Universal::new(compiler).engine();
+        let compiler = wasmer_compiler_cranelift::Cranelift::default();
+        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        Store::new(&engine)
+    }
+
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+    fn default_store() -> wasmer::Store {
+        let compiler = wasmer_compiler_singlepass::Singlepass::default();
+        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
         Store::new(&engine)
     }
 

--- a/examples/example-rust-wasmer-runtime/Cargo.toml
+++ b/examples/example-rust-wasmer-runtime/Cargo.toml
@@ -24,9 +24,16 @@ time = { version = "0.3", features = [
   "macros",
 ] }
 tokio = { version = "1.9.0", features = ["rt", "macros"] }
-wasmer = { version = "2.3", default-features = false, features = ["singlepass", "default-engine"] }
+wasmer = { version = "2.3", default-features = false }
 wasmer-wasi = "2.3"
+wasmer-engine-universal = { version = "2.3", features = ["compiler"] }
 anyhow = "1.0"
 
 [features]
 wasi = []
+
+[target.'cfg(any(target_arch = "arm", target_arch = "aarch64"))'.dependencies]
+wasmer-compiler-cranelift = { version = "2.3" }
+
+[target.'cfg(not(any(target_arch = "arm", target_arch = "aarch64")))'.dependencies]
+wasmer-compiler-singlepass = { version = "2.3" }

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -350,13 +350,21 @@ impl Runtime {{
         let module = Module::new(&store, wasm_module)?;
         Ok(Self {{ module }})
     }}
-
+    
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {{
-        let compiler = wasmer::Singlepass::default();
-        let engine = wasmer::Universal::new(compiler).engine();
+        let compiler = wasmer_compiler_cranelift::Cranelift::default();
+        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
         Store::new(&engine)
     }}
-
+    
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+    fn default_store() -> wasmer::Store {{
+        let compiler = wasmer_compiler_singlepass::Singlepass::default();
+        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        Store::new(&engine)
+    }}
+    
     {exports}
 }}
 


### PR DESCRIPTION
This reverts commit dba48e6769d3be7d65980d6a2dff34d1b2f9a594.