### PR TITLE
Fix 'Singlepass' import for Runtime bindings. 

### DIFF
--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -13,7 +13,8 @@ use fp_bindgen_support::{
 };
 use std::sync::Arc;
 use wasmer::{
-    imports, AsStoreMut, Function, FunctionEnv, FunctionEnvMut, Imports, Instance, Module, Store,
+    imports, AsStoreMut, Function, FunctionEnv, FunctionEnvMut, Imports, Instance, Module,
+    Singlepass, Store,
 };
 
 pub struct Runtime {
@@ -41,7 +42,7 @@ impl Runtime {
     }
 
     fn default_store() -> wasmer::Store {
-        Store::new(wasmer_compiler_singlepass::Singlepass::default())
+        Store::new(Singlepass::default())
     }
 
     fn function_env_mut(&mut self) -> FunctionEnvMut<Arc<RuntimeInstanceData>> {

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -13,7 +13,8 @@ use fp_bindgen_support::{
 };
 use std::sync::Arc;
 use wasmer::{
-    imports, AsStoreMut, Function, FunctionEnv, FunctionEnvMut, Imports, Instance, Module, Store,
+    imports, AsStoreMut, Function, FunctionEnv, FunctionEnvMut, Imports, Instance, Module,
+    Singlepass, Store,
 };
 
 pub struct Runtime {
@@ -46,7 +47,7 @@ impl Runtime {
     }
 
     fn default_store() -> wasmer::Store {
-        Store::new(wasmer_compiler_singlepass::Singlepass::default())
+        Store::new(Singlepass::default())
     }
 
     fn function_env_mut(&mut self) -> FunctionEnvMut<Arc<RuntimeInstanceData>> {

--- a/examples/example-rust-wasmer-runtime/Cargo.toml
+++ b/examples/example-rust-wasmer-runtime/Cargo.toml
@@ -25,8 +25,7 @@ time = { version = "0.3", features = [
 ] }
 tokio = { version = "1.9.0", features = ["rt", "macros"] }
 tracing = "0.1.37"
-wasmer = { version = "3", default-features = false }
-wasmer-compiler-singlepass = { version = "3" }
+wasmer = { version = "3", default-features = false, features = ["singlepass"] }
 wasmer-wasi = "3"
 anyhow = "1.0"
 

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -353,7 +353,7 @@ use fp_bindgen_support::{{
     }},
 }};
 use std::sync::Arc;
-use wasmer::{{imports, AsStoreMut, Function, FunctionEnv, FunctionEnvMut, Imports, Instance, Module, Store}};
+use wasmer::{{imports, AsStoreMut, Function, FunctionEnv, FunctionEnvMut, Imports, Instance, Module, Store, Singlepass}};
 
 pub struct Runtime {{
     store: Store,
@@ -365,7 +365,7 @@ impl Runtime {{
     {new_func}
 
     fn default_store() -> wasmer::Store {{
-        Store::new(wasmer_compiler_singlepass::Singlepass::default())
+        Store::new(Singlepass::default())
     }}
 
     fn function_env_mut(&mut self) -> FunctionEnvMut<Arc<RuntimeInstanceData>> {{


### PR DESCRIPTION
Opening this to tackle this issue: https://github.com/fiberplane/fp-bindgen/issues/161


### Changes:
- Just updated the import of `Singlepass` from wasmer. 