### PR TITLE
Simplify the rust-module annotation so it works the same for all generators that choose to support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make sure `cargo check` doesn't complain about unused imports in the generated
   plugin bindings.
 - Add support for `serde_json::Map` (https://github.com/fiberplane/fp-bindgen/pull/163)
+- Replace the `rust_plugin_module` and `rust_wasmer_runtime_module` annotations with a single `rust_module` annotation.
 
 ## 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Please note that in this case, you do have a bigger responsibility to make sure 
 fulfills the requirements of the code generator, hence why Serde's trait derives and annotations
 have to be added manually here, in accordance with how the generator would otherwise generate them.
 
-For now, this feature is limited to the Rust generators throug the
+For now, this feature is limited to the Rust generators through the
 `rust_module` annotation. For us, this makes sense given the
 protocol itself is specified using Rust syntax as well. If desired, we could extend this to the
 TypeScript generator as well, though that would imply an even bigger responsibility for the user to

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ definition instead of generating a new one:
 use fp_bindgen::prelude::Serializable;
 
 #[derive(Serializable)]
-#[fp(rust_wasmer_runtime_module = "my_crate::prelude")]
+#[fp(rust_module = "my_crate::prelude")]
 pub struct MyStruct {
     pub foo: i32,
     pub bar_qux: String,
@@ -140,8 +140,8 @@ Please note that in this case, you do have a bigger responsibility to make sure 
 fulfills the requirements of the code generator, hence why Serde's trait derives and annotations
 have to be added manually here, in accordance with how the generator would otherwise generate them.
 
-For now, this feature is limited to the Rust generators through either the
-`rust_wasmer_runtime_module` or `rust_plugin_module` annotations. For us, this makes sense given the
+For now, this feature is limited to the Rust generators throug the
+`rust_module` annotation. For us, this makes sense given the
 protocol itself is specified using Rust syntax as well. If desired, we could extend this to the
 TypeScript generator as well, though that would imply an even bigger responsibility for the user to
 keep their TypeScript types in sync with the protocol.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,9 +29,8 @@ The file [`reducer.rs`](example-plugin/src/reducer.rs) is an example of how to i
 reducer in Rust.
 
 Note that the plugin also depends on the [`redux-example`](#redux-example) crate for access to the
-Redux types. This is also a demonstration of how to use the `#[fp(rust_plugin_module = "...")]` and
-`#[fp(rust_wasmer_runtime_module = "...")]` annotations to share types between the protocol
-definition and the dependent Rust crates.
+Redux types. This is also a demonstration of how to use the `#[fp(rust_module = "...")]` annotation
+to share types between the protocol definition and the dependent Rust crates.
 
 ## `example-deno-runtime/`
 

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_types.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_types.rs
@@ -2,6 +2,9 @@
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, rc::Rc};
 
+pub use redux_example::ReduxAction;
+pub use redux_example::StateUpdate;
+
 pub type Body = serde_bytes::ByteBuf;
 
 /// # This is an enum with doc comments.
@@ -134,14 +137,6 @@ pub struct Point<T> {
     pub value: T,
 }
 
-/// Example for representing Redux actions.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
-pub enum ReduxAction {
-    ClearTitle,
-    UpdateTitle { title: String },
-}
-
 /// Represents an HTTP request to be sent.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Request {
@@ -249,19 +244,6 @@ pub enum SerdeVariantRenaming {
         #[serde(rename = "qux_baz")]
         qux_baz: f64,
     },
-}
-
-/// A state update to communicate to the Redux host.
-///
-/// Fields are wrapped in `Option`. If any field is `None` it means it hasn't
-/// changed.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StateUpdate {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<Rc<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub revision: Option<u16>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/examples/example-protocol/src/types/time.rs
+++ b/examples/example-protocol/src/types/time.rs
@@ -8,7 +8,7 @@ use time::OffsetDateTime;
 // is recommended because you can pass these directly to the JavaScript `Date`
 // constructor. The Serde attributes to enable RFC3339 formatting are inserted
 // automatically by the bindings generator, but you may have to add them
-// yourself if you using annotations such as `#[fp(rust_plugin_module)]`.
+// yourself if you using annotations such as `#[fp(rust_module)]`.
 //
 // If you do not use RFC3339 formatting, you should expect your date/time types
 // to only work from Rust to Rust.

--- a/examples/redux-example/src/lib.rs
+++ b/examples/redux-example/src/lib.rs
@@ -4,10 +4,7 @@ use std::rc::Rc;
 
 /// Example for representing Redux actions.
 #[derive(Serializable, Serialize, Deserialize)]
-#[fp(
-    rust_plugin_module = "redux_example",
-    rust_wasmer_runtime_module = "redux_example"
-)]
+#[fp(rust_module = "redux_example")]
 #[serde(rename_all = "snake_case", tag = "type", content = "payload")]
 pub enum ReduxAction {
     ClearTitle,
@@ -20,10 +17,7 @@ pub enum ReduxAction {
 /// cheaply clone the state, as well as to cheaply perform a diff between the
 /// old and new state. This is done in `StateUpdate::from_states()`.
 #[derive(Clone, Default, Serializable, Serialize, Deserialize)]
-#[fp(
-    rust_plugin_module = "redux_example",
-    rust_wasmer_runtime_module = "redux_example"
-)]
+#[fp(rust_module = "redux_example")]
 #[serde(rename_all = "camelCase")]
 pub struct ReduxState {
     pub title: Rc<String>,
@@ -35,10 +29,7 @@ pub struct ReduxState {
 /// Fields are wrapped in `Option`. If any field is `None` it means it hasn't
 /// changed.
 #[derive(Serializable, Serialize, Deserialize)]
-#[fp(
-    rust_plugin_module = "redux_example",
-    rust_wasmer_runtime_module = "redux_example"
-)]
+#[fp(rust_module = "redux_example")]
 #[serde(rename_all = "camelCase")]
 pub struct StateUpdate {
     pub title: Option<Rc<String>>,

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -17,7 +17,7 @@ pub(crate) fn generate_bindings(
 
     // We use the same type generation as for the Rust plugin, only with the
     // serializable and deserializable types inverted:
-    generate_type_bindings(&types, path, "rust_wasmer_runtime");
+    generate_type_bindings(&types, path);
 
     generate_function_bindings(import_functions, export_functions, &types, path);
 }

--- a/fp-bindgen/src/generators/rust_wasmer_wasi_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_wasi_runtime/mod.rs
@@ -19,7 +19,7 @@ pub(crate) fn generate_bindings(
 
     // We use the same type generation as for the Rust plugin, only with the
     // serializable and deserializable types inverted:
-    generate_type_bindings(&types, path, "rust_wasmer_wasi_runtime");
+    generate_type_bindings(&types, path);
 
     generate_function_bindings(import_functions, export_functions, &types, path);
 }

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -138,8 +138,8 @@ Please note that in this case, you do have a bigger responsibility to make sure 
 fulfills the requirements of the code generator, hence why Serde's trait derives and annotations
 have to be added manually here, in accordance with how the generator would otherwise generate them.
 
-For now, this feature is limited to the Rust generators through either the
-`rust_wasmer_runtime_module` or `rust_plugin_module` annotations. For us, this makes sense given the
+For now, this feature is limited to the Rust generators through the
+`rust_module` annotation. For us, this makes sense given the
 protocol itself is specified using Rust syntax as well. If desired, we could extend this to the
 TypeScript generator as well, though that would imply an even bigger responsibility for the user to
 keep their TypeScript types in sync with the protocol.


### PR DESCRIPTION
Cleans up that annotation and simplifies the code related to it.