### PR TITLE
Add a 'clean' xtask that cleans all target folders and generated bindings

### DIFF
--- a/xtask/src/clean.rs
+++ b/xtask/src/clean.rs
@@ -1,0 +1,28 @@
+use crate::utils::{from_root, ProgressReporter};
+use crate::TaskResult;
+use console::Emoji;
+use std::fs::metadata;
+
+static BROOM: Emoji<'_, '_> = Emoji("🧹 ", "");
+
+pub fn clean() -> TaskResult<()> {
+    let paths = vec![
+        "target",
+        "examples/example-plugin/target",
+        "examples/example-protocol/bindings",
+        "examples/example-rust-wasmer-runtime/target",
+    ];
+    let mut progress = ProgressReporter::new(paths.len());
+
+    for path in paths {
+        progress.report(BROOM, &format!("Deleting: {}", &path));
+        let full_path = from_root(path);
+        if let Ok(metadata) = metadata(&full_path) {
+            if metadata.is_dir() {
+                std::fs::remove_dir_all(full_path)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,4 @@
+mod clean;
 mod test;
 mod utils;
 
@@ -17,6 +18,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Cleans all target folders
+    Clean,
     /// Builds test protocol and plugin and runs all available tests
     Test,
 }
@@ -31,6 +34,7 @@ fn handle_cli() -> TaskResult<()> {
     let cli = Cli::parse();
 
     match &cli.command {
+        Some(Commands::Clean) => clean::clean()?,
         Some(Commands::Test) => test::test()?,
         None => {}
     }


### PR DESCRIPTION
I added this since I had some issues after updating Rust, and running `cargo clean` in the root folder doesn't clean up enough.