### PR TITLE
Call `enable_all` on Tokio runtime

### DIFF
--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -1391,6 +1391,7 @@ pub fn _make_http_request(
     let async_ptr = create_future_value(&mut env);
     let result: Vec<u8> = std::thread::spawn(|| {
         let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
             .unwrap();
         rt.block_on(async move { rmp_serde::to_vec(&result.await).unwrap() })

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -1532,6 +1532,7 @@ pub fn _make_http_request(
     let async_ptr = create_future_value(&mut env);
     let result: Vec<u8> = std::thread::spawn(|| {
         let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
             .unwrap();
         rt.block_on(async move { rmp_serde::to_vec(&result.await).unwrap() })

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -275,6 +275,7 @@ pub(crate) fn format_export_function(function: &Function, types: &TypeMap) -> St
         r#"let async_ptr = create_future_value(&mut env);
     let result: Vec<u8> = std::thread::spawn(|| {
         let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
             .unwrap();
         rt.block_on(async move {


### PR DESCRIPTION
The Tokio runtime that gets created ad-hoc to deal with awaiting async results did not get IO enabled. This causes any WASM code that is trying to wait for something like an HTTP request to blow up.