### PR TITLE
Fix imports in generated bindings

### DIFF
--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -33,15 +33,15 @@ impl Runtime {
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer_compiler_cranelift::Cranelift::default();
-        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        let compiler = wasmer::Cranelift::default();
+        let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }
 
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer_compiler_singlepass::Singlepass::default();
-        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        let compiler = wasmer::Singlepass::default();
+        let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }
 

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -36,15 +36,15 @@ impl Runtime {
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer_compiler_cranelift::Cranelift::default();
-        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        let compiler = wasmer::Cranelift::default();
+        let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }
 
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     fn default_store() -> wasmer::Store {
-        let compiler = wasmer_compiler_singlepass::Singlepass::default();
-        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        let compiler = wasmer::Singlepass::default();
+        let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }
 

--- a/examples/example-rust-wasmer-runtime/Cargo.toml
+++ b/examples/example-rust-wasmer-runtime/Cargo.toml
@@ -25,16 +25,9 @@ time = { version = "0.3", features = [
 ] }
 tokio = { version = "1.9.0", features = ["rt", "macros"] }
 tracing = "0.1.37"
-wasmer = { version = "2.3", default-features = false }
+wasmer = { version = "2.3", features = ["compiler", "cranelift", "singlepass"] }
 wasmer-wasi = "2.3"
-wasmer-engine-universal = { version = "2.3", features = ["compiler"] }
 anyhow = "1.0"
 
 [features]
 wasi = []
-
-[target.'cfg(any(target_arch = "arm", target_arch = "aarch64"))'.dependencies]
-wasmer-compiler-cranelift = { version = "2.3" }
-
-[target.'cfg(not(any(target_arch = "arm", target_arch = "aarch64")))'.dependencies]
-wasmer-compiler-singlepass = { version = "2.3" }

--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -361,15 +361,15 @@ impl Runtime {{
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn default_store() -> wasmer::Store {{
-        let compiler = wasmer_compiler_cranelift::Cranelift::default();
-        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        let compiler = wasmer::Cranelift::default();
+        let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }}
 
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     fn default_store() -> wasmer::Store {{
-        let compiler = wasmer_compiler_singlepass::Singlepass::default();
-        let engine = wasmer_engine_universal::Universal::new(compiler).engine();
+        let compiler = wasmer::Singlepass::default();
+        let engine = wasmer::Universal::new(compiler).engine();
         Store::new(&engine)
     }}
 


### PR DESCRIPTION
Imports were apparently using direct crate references, instead of using the names re-exported from the main `wasmer` crate.

We don't want this, since this forces users to add extra crates to their project.