### PR TITLE
cargo_dependency: add git helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add support for `serde_json::Map`
   (https://github.com/fiberplane/fp-bindgen/pull/163).
 - Added support for specifying custom Cargo registries with `CargoDependency`.
+- Added helpers for building `CargoDependency` with a git repository.
 
 ### Changed
 

--- a/fp-bindgen/src/types/cargo_dependency.rs
+++ b/fp-bindgen/src/types/cargo_dependency.rs
@@ -128,10 +128,7 @@ impl CargoDependency {
         Self::with_git_and_features(git, BTreeSet::new())
     }
 
-    pub fn with_git_and_features(
-        git: &'static str,
-        features: BTreeSet<&'static str>,
-    ) -> Self {
+    pub fn with_git_and_features(git: &'static str, features: BTreeSet<&'static str>) -> Self {
         Self {
             features,
             git: Some(git),

--- a/fp-bindgen/src/types/cargo_dependency.rs
+++ b/fp-bindgen/src/types/cargo_dependency.rs
@@ -123,6 +123,38 @@ impl CargoDependency {
             ..Default::default()
         }
     }
+
+    pub fn with_git(git: &'static str) -> Self {
+        Self::with_git_and_features(git, BTreeSet::new())
+    }
+
+    pub fn with_git_and_features(
+        git: &'static str,
+        features: BTreeSet<&'static str>,
+    ) -> Self {
+        Self {
+            features,
+            git: Some(git),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_git_and_branch(git: &'static str, branch: &'static str) -> Self {
+        Self::with_git_and_branch_and_features(git, branch, BTreeSet::new())
+    }
+
+    pub fn with_git_and_branch_and_features(
+        git: &'static str,
+        branch: &'static str,
+        features: BTreeSet<&'static str>,
+    ) -> Self {
+        Self {
+            features,
+            git: Some(git),
+            branch: Some(branch),
+            ..Default::default()
+        }
+    }
 }
 
 impl fmt::Display for CargoDependency {


### PR DESCRIPTION
Howdy!

This change allows use of the `git` and `branch` fields on `CargoDependency`. As far as I can tell, these are unusable w/o a helper because `CargoDependency` is _non exhaustive_ and _immutable_. 

I'm not sure if it's worth having four methods here. Perhaps `with_git_and_branch` and `with_git_and_branch_and_features` is sufficient. 