### PR TITLE
Add support for adding 'description' and 'license' fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   changes.
 - Add `description` and `license` fields to `RustPluginConfig`. These are optional
   so to upgrade from earlier versions of `fp-bindgen` you may set these fields to `None`.
+- The `authors`, `description` and `license` fields in `RustPluginConfig` will not add quotes
+  if they are not needed (e.g. when setting them to values like `{ workspace = true }`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format of this file is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0-beta.2] - Unreleased
+
+### Changed
+
+- Add `description` and `license` fields to `RustPluginConfig`. These are optional
+  so to upgrade from earlier versions of `fp-bindgen` you may set these fields to `None`.
+- The `authors`, `description` and `license` fields in `RustPluginConfig` will not add quotes
+  if they are not needed (e.g. when setting them to values like `{ workspace = true }`).
+
 ## [3.0.0-beta.1] - 2023-02-14
 
 ### Added
@@ -26,10 +35,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   annotations that were not there in the original protocol definition.
 - `CargoDependency` is now marked as non-exhaustive to prevent future breaking
   changes.
-- Add `description` and `license` fields to `RustPluginConfig`. These are optional
-  so to upgrade from earlier versions of `fp-bindgen` you may set these fields to `None`.
-- The `authors`, `description` and `license` fields in `RustPluginConfig` will not add quotes
-  if they are not needed (e.g. when setting them to values like `{ workspace = true }`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   annotations that were not there in the original protocol definition.
 - `CargoDependency` is now marked as non-exhaustive to prevent future breaking
   changes.
+- Add `description` and `license` fields to `RustPluginConfig`. These are optional
+  so to upgrade from earlier versions of `fp-bindgen` you may set these fields to `None`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Add `description` and `license` fields to `RustPluginConfig`. These are optional
-  so to upgrade from earlier versions of `fp-bindgen` you may set these fields to `None`.
-- The `authors`, `description` and `license` fields in `RustPluginConfig` will not add quotes
-  if they are not needed (e.g. when setting them to values like `{ workspace = true }`).
+- `RustPluginConfig` now needs to be initialized using `RustPluginConfig::builder()`. Struct
+  initialization syntax will not work anymore.
+- Every field in the `RustPluginConfig` builder can be set to `RustPluginConfigValue::Workspace`
+  to indicate the value in the generated `Cargo.toml` should come from the workspace instead.
+- Add `description` and `license` fields to `RustPluginConfig`.
 
 ## [3.0.0-beta.1] - 2023-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   initialization syntax will not work anymore.
 - Every field in the `RustPluginConfig` builder can be set to `RustPluginConfigValue::Workspace`
   to indicate the value in the generated `Cargo.toml` should come from the workspace instead.
-- Add `description` and `license` fields to `RustPluginConfig`.
+- Add `description`, `readme` and `license` fields to `RustPluginConfig`.
 
 ## [3.0.0-beta.1] - 2023-02-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ members = [
 ]
 
 [workspace.dependencies]
-fp-bindgen-macros = { version = "3.0.0-beta.1", path = "macros" }
+fp-bindgen-macros = { version = "3.0.0-beta.2", path = "macros" }
 
 [workspace.package]
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 
 [dependencies]
 bytes = { version = "1", features = ["serde"] }
-fp-bindgen-support = { path = "../../../../fp-bindgen-support", version = "3.0.0-beta.1", features = ["async", "guest", "http"] }
+fp-bindgen-support = { path = "../../../../fp-bindgen-support", version = "3.0.0-beta.2", features = ["async", "guest", "http"] }
 http = { version = "0.2" }
 once_cell = { version = "1" }
 redux-example = { path = "../../../redux-example" }

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 description = "Bindings to the fp-bindgen example protocol"
+readme = "README.md"
 license = { workspace = true }
 
 [dependencies]

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 description = "Bindings to the fp-bindgen example protocol"
-license = "MIT OR Apache-2.0"
+license = { workspace = true }
 
 [dependencies]
 bytes = { version = "1", features = ["serde"] }

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo_no_optionals.toml
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo_no_optionals.toml
@@ -3,8 +3,6 @@ name = "example-bindings"
 version = "1.0.0"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
-description = "Bindings to the fp-bindgen example protocol"
-license = "MIT OR Apache-2.0"
 
 [dependencies]
 bytes = { version = "1", features = ["serde"] }

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo_no_optionals.toml
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_Cargo_no_optionals.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bytes = { version = "1", features = ["serde"] }
-fp-bindgen-support = { path = "../../../../fp-bindgen-support", version = "3.0.0-beta.1", features = ["async", "guest", "http"] }
+fp-bindgen-support = { path = "../../../../fp-bindgen-support", version = "3.0.0-beta.2", features = ["async", "guest", "http"] }
 http = { version = "0.2" }
 once_cell = { version = "1" }
 redux-example = { path = "../../../redux-example" }

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -301,8 +301,8 @@ fn test_generate_rust_plugin() {
             name: NAME,
             authors: AUTHORS,
             version: VERSION,
-            description: None,
-            license: None,
+            description: Some(DESCRIPTION),
+            license: Some(LICENSE),
             dependencies: PLUGIN_DEPENDENCIES.clone(),
         }),
         path: "bindings/rust-plugin",
@@ -311,6 +311,26 @@ fn test_generate_rust_plugin() {
     for (path, expected) in FILES {
         tests::assert_file_eq(path, expected)
     }
+}
+
+#[test]
+fn test_generate_rust_plugin_without_optional_fields() {
+    fp_bindgen!(BindingConfig {
+        bindings_type: BindingsType::RustPlugin(RustPluginConfig {
+            name: NAME,
+            authors: AUTHORS,
+            version: VERSION,
+            description: None,
+            license: None,
+            dependencies: PLUGIN_DEPENDENCIES.clone(),
+        }),
+        path: "bindings/rust-plugin-no-optionals",
+    });
+
+    tests::assert_file_eq(
+        "bindings/rust-plugin-no-optionals/Cargo.toml",
+        include_bytes!("assets/rust_plugin_test/expected_Cargo_no_optionals.toml"),
+    );
 }
 
 #[test]

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -218,10 +218,13 @@ fp_export! {
 }
 
 const VERSION: &str = "1.0.0";
-const AUTHORS: &str = r#"["Fiberplane <info@fiberplane.com>"]"#;
 const NAME: &str = "example-bindings";
-const DESCRIPTION: &str = r#"Bindings to the fp-bindgen example protocol"#;
-const LICENSE: &str = r#"MIT OR Apache-2.0"#;
+const DESCRIPTION: &str = "Bindings to the fp-bindgen example protocol";
+const LICENSE: &str = "MIT OR Apache-2.0";
+
+fn authors() -> Vec<String> {
+    vec!["Fiberplane <info@fiberplane.com>".to_string()]
+}
 
 static PLUGIN_DEPENDENCIES: Lazy<BTreeMap<&str, CargoDependency>> = Lazy::new(|| {
     BTreeMap::from([
@@ -245,14 +248,16 @@ static PLUGIN_DEPENDENCIES: Lazy<BTreeMap<&str, CargoDependency>> = Lazy::new(||
 
 fn main() {
     for bindings_type in [
-        BindingsType::RustPlugin(RustPluginConfig {
-            name: NAME,
-            authors: AUTHORS,
-            version: VERSION,
-            description: Some(DESCRIPTION),
-            license: Some(LICENSE),
-            dependencies: PLUGIN_DEPENDENCIES.clone(),
-        }),
+        BindingsType::RustPlugin(
+            RustPluginConfig::builder()
+                .name(NAME)
+                .authors(authors())
+                .version(VERSION)
+                .description(DESCRIPTION)
+                .license(LICENSE)
+                .dependencies(PLUGIN_DEPENDENCIES.clone())
+                .build(),
+        ),
         BindingsType::RustWasmerRuntime,
         BindingsType::RustWasmerWasiRuntime,
         BindingsType::TsRuntimeWithExtendedConfig(
@@ -297,14 +302,16 @@ fn test_generate_rust_plugin() {
     ];
 
     fp_bindgen!(BindingConfig {
-        bindings_type: BindingsType::RustPlugin(RustPluginConfig {
-            name: NAME,
-            authors: AUTHORS,
-            version: VERSION,
-            description: Some(DESCRIPTION),
-            license: Some("{ workspace = true }"),
-            dependencies: PLUGIN_DEPENDENCIES.clone(),
-        }),
+        bindings_type: BindingsType::RustPlugin(
+            RustPluginConfig::builder()
+                .name(NAME)
+                .authors(authors())
+                .version(VERSION)
+                .description(DESCRIPTION)
+                .license(RustPluginConfigValue::Workspace)
+                .dependencies(PLUGIN_DEPENDENCIES.clone())
+                .build()
+        ),
         path: "bindings/rust-plugin",
     });
 
@@ -316,14 +323,14 @@ fn test_generate_rust_plugin() {
 #[test]
 fn test_generate_rust_plugin_without_optional_fields() {
     fp_bindgen!(BindingConfig {
-        bindings_type: BindingsType::RustPlugin(RustPluginConfig {
-            name: NAME,
-            authors: AUTHORS,
-            version: VERSION,
-            description: None,
-            license: None,
-            dependencies: PLUGIN_DEPENDENCIES.clone(),
-        }),
+        bindings_type: BindingsType::RustPlugin(
+            RustPluginConfig::builder()
+                .name(NAME)
+                .authors(authors())
+                .version(VERSION)
+                .dependencies(PLUGIN_DEPENDENCIES.clone())
+                .build()
+        ),
         path: "bindings/rust-plugin-no-optionals",
     });
 

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -310,6 +310,7 @@ fn test_generate_rust_plugin() {
                 .description(DESCRIPTION)
                 .license(RustPluginConfigValue::Workspace)
                 .dependencies(PLUGIN_DEPENDENCIES.clone())
+                .readme("README.md")
                 .build()
         ),
         path: "bindings/rust-plugin",
@@ -321,7 +322,7 @@ fn test_generate_rust_plugin() {
 }
 
 #[test]
-fn test_generate_rust_plugin_without_optional_fields() {
+fn test_generate_rust_plugin_without_some_fields() {
     fp_bindgen!(BindingConfig {
         bindings_type: BindingsType::RustPlugin(
             RustPluginConfig::builder()

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -220,6 +220,8 @@ fp_export! {
 const VERSION: &str = "1.0.0";
 const AUTHORS: &str = r#"["Fiberplane <info@fiberplane.com>"]"#;
 const NAME: &str = "example-bindings";
+const DESCRIPTION: &str = r#"Bindings to the fp-bindgen example protocol"#;
+const LICENSE: &str = r#"MIT OR Apache-2.0"#;
 
 static PLUGIN_DEPENDENCIES: Lazy<BTreeMap<&str, CargoDependency>> = Lazy::new(|| {
     BTreeMap::from([
@@ -247,6 +249,8 @@ fn main() {
             name: NAME,
             authors: AUTHORS,
             version: VERSION,
+            description: Some(DESCRIPTION),
+            license: Some(LICENSE),
             dependencies: PLUGIN_DEPENDENCIES.clone(),
         }),
         BindingsType::RustWasmerRuntime,
@@ -297,6 +301,8 @@ fn test_generate_rust_plugin() {
             name: NAME,
             authors: AUTHORS,
             version: VERSION,
+            description: None,
+            license: None,
             dependencies: PLUGIN_DEPENDENCIES.clone(),
         }),
         path: "bindings/rust-plugin",

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -302,7 +302,7 @@ fn test_generate_rust_plugin() {
             authors: AUTHORS,
             version: VERSION,
             description: Some(DESCRIPTION),
-            license: Some(LICENSE),
+            license: Some("{ workspace = true }"),
             dependencies: PLUGIN_DEPENDENCIES.clone(),
         }),
         path: "bindings/rust-plugin",

--- a/fp-bindgen/Cargo.toml
+++ b/fp-bindgen/Cargo.toml
@@ -29,7 +29,7 @@ rmpv-compat = ["rmpv"]
 serde-bytes-compat = ["serde_bytes"]
 serde-json-compat = ["serde_json"]
 time-compat = ["time"]
-generators = ["rustfmt-wrapper"]
+generators = ["rustfmt-wrapper", "toml_edit"]
 
 [dependencies]
 bytes = { version = "1", features = ["serde"], optional = true }
@@ -44,4 +44,5 @@ serde_bytes = { version = "0.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 syn = { version = "1", features = ["full", "extra-traits"] }
 time = { version = "0.3", features = ["serde-human-readable"], optional = true }
+toml_edit = { version = "0.19", optional = true }
 rustfmt-wrapper = { version = "0.1.0", optional = true }

--- a/fp-bindgen/src/generators/mod.rs
+++ b/fp-bindgen/src/generators/mod.rs
@@ -58,6 +58,12 @@ pub struct RustPluginConfig<'a> {
     /// these dependencies yourself can be useful if you want to explicitly bump
     /// a dependency version or you want to enable a Cargo feature in them.
     pub dependencies: BTreeMap<&'a str, CargoDependency>,
+
+    /// The human-readable description for the generated crate.
+    pub description: Option<&'a str>,
+
+    /// The license of the generated crate.
+    pub license: Option<&'a str>,
 }
 
 #[non_exhaustive]

--- a/fp-bindgen/src/generators/mod.rs
+++ b/fp-bindgen/src/generators/mod.rs
@@ -63,6 +63,9 @@ pub struct RustPluginConfig {
     /// The human-readable description for the generated crate.
     pub description: Option<RustPluginConfigValue>,
 
+    /// A readme file containing some information for the generated crate.
+    pub readme: Option<RustPluginConfigValue>,
+
     /// The license of the generated crate.
     pub license: Option<RustPluginConfigValue>,
 }
@@ -76,6 +79,7 @@ impl RustPluginConfig {
                 version: None,
                 dependencies: Default::default(),
                 description: None,
+                readme: None,
                 license: None,
             },
         }
@@ -134,8 +138,26 @@ impl RustPluginConfigBuilder {
         self
     }
 
+    pub fn author(mut self, value: impl Into<String>) -> Self {
+        match &mut self.config.authors {
+            Some(RustPluginConfigValue::Vec(vec)) => {
+                vec.push(value.into());
+            }
+            None => {
+                self.config.authors = Some(RustPluginConfigValue::Vec(vec![value.into()]));
+            }
+            _ => panic!("Cannot add an author to a non-vector 'authors' field"),
+        }
+        self
+    }
+
     pub fn description(mut self, value: impl Into<RustPluginConfigValue>) -> Self {
         self.config.description = Some(value.into());
+        self
+    }
+
+    pub fn readme(mut self, value: impl Into<RustPluginConfigValue>) -> Self {
+        self.config.readme = Some(value.into());
         self
     }
 

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -100,7 +100,7 @@ fn generate_cargo_file(
         format!(
             "[package]
 name = \"{}\"
-version = \"{}\"
+version = {}
 authors = {}
 edition = \"2018\"{}{}
 
@@ -108,15 +108,21 @@ edition = \"2018\"{}{}
 {}
 ",
             config.name,
-            config.version,
+            maybe_quote_str(config.version),
             config.authors,
             config
                 .description
-                .map(|description| format!("\ndescription = \"{description}\""))
+                .map(|description| {
+                    let description = maybe_quote_str(description);
+                    format!("\ndescription = {description}")
+                })
                 .unwrap_or_default(),
             config
                 .license
-                .map(|license| format!("\nlicense = \"{license}\""))
+                .map(|license| {
+                    let license = maybe_quote_str(license);
+                    format!("\nlicense = {license}")
+                })
                 .unwrap_or_default(),
             dependencies
                 .iter()
@@ -585,4 +591,12 @@ where
     C: AsRef<[u8]>,
 {
     fs::write(file_path, &contents).expect("Could not write bindings file");
+}
+
+fn maybe_quote_str(input: &str) -> String {
+    if input.trim_start().starts_with('{') {
+        input.to_string()
+    } else {
+        format!("\"{input}\"")
+    }
 }

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -1,10 +1,12 @@
 use crate::functions::Function;
+use crate::generators::RustPluginConfigValue;
 use crate::types::is_runtime_bound;
 use crate::{
     functions::FunctionList,
     types::{CargoDependency, Enum, Field, Struct, Type, TypeIdent, TypeMap},
     RustPluginConfig,
 };
+use std::iter::FromIterator;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
@@ -86,9 +88,9 @@ fn generate_cargo_file(
     }
 
     // Inject dependencies passed through the config:
-    for (name, dependency) in config.dependencies {
-        let dependency = if let Some(existing_dependency) = dependencies.remove(name) {
-            existing_dependency.merge_or_replace_with(&dependency)
+    for (name, dependency) in &config.dependencies {
+        let dependency = if let Some(existing_dependency) = dependencies.remove(name.as_str()) {
+            existing_dependency.merge_or_replace_with(dependency)
         } else {
             dependency.clone()
         };
@@ -99,31 +101,16 @@ fn generate_cargo_file(
         format!("{path}/Cargo.toml"),
         format!(
             "[package]
-name = \"{}\"
-version = {}
-authors = {}
-edition = \"2018\"{}{}
-
+{}{}{}edition = \"2018\"
+{}{}
 [dependencies]
 {}
 ",
-            config.name,
-            maybe_quote_str(config.version),
-            config.authors,
-            config
-                .description
-                .map(|description| {
-                    let description = maybe_quote_str(description);
-                    format!("\ndescription = {description}")
-                })
-                .unwrap_or_default(),
-            config
-                .license
-                .map(|license| {
-                    let license = maybe_quote_str(license);
-                    format!("\nlicense = {license}")
-                })
-                .unwrap_or_default(),
+            format_cargo_key("name", config.name),
+            format_cargo_key("version", config.version),
+            format_cargo_key("authors", config.authors),
+            format_cargo_key("description", config.description),
+            format_cargo_key("license", config.license),
             dependencies
                 .iter()
                 .map(|(name, value)| format!("{name} = {value}"))
@@ -593,10 +580,22 @@ where
     fs::write(file_path, &contents).expect("Could not write bindings file");
 }
 
-fn maybe_quote_str(input: &str) -> String {
-    if input.trim_start().starts_with('{') {
-        input.to_string()
+fn format_cargo_key(key: &str, value: Option<RustPluginConfigValue>) -> String {
+    if let Some(value) = value {
+        let toml_value = match value {
+            RustPluginConfigValue::String(str) => toml_edit::value(str),
+            RustPluginConfigValue::Vec(vec) => toml_edit::value(toml_edit::Array::from_iter(vec)),
+            RustPluginConfigValue::Workspace => {
+                let mut inline = toml_edit::InlineTable::new();
+                inline.insert("workspace", true.into());
+                toml_edit::value(inline)
+            }
+        };
+
+        let mut doc = toml_edit::Document::new();
+        doc[key] = toml_value;
+        doc.to_string()
     } else {
-        format!("\"{input}\"")
+        "".to_string()
     }
 }

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -102,7 +102,7 @@ fn generate_cargo_file(
         format!(
             "[package]
 {}{}{}edition = \"2018\"
-{}{}
+{}{}{}
 [dependencies]
 {}
 ",
@@ -110,6 +110,7 @@ fn generate_cargo_file(
             format_cargo_key("version", config.version),
             format_cargo_key("authors", config.authors),
             format_cargo_key("description", config.description),
+            format_cargo_key("readme", config.readme),
             format_cargo_key("license", config.license),
             dependencies
                 .iter()

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -102,7 +102,7 @@ fn generate_cargo_file(
 name = \"{}\"
 version = \"{}\"
 authors = {}
-edition = \"2018\"
+edition = \"2018\"{}{}
 
 [dependencies]
 {}
@@ -110,6 +110,14 @@ edition = \"2018\"
             config.name,
             config.version,
             config.authors,
+            config
+                .description
+                .map(|description| format!("\ndescription = \"{description}\""))
+                .unwrap_or_default(),
+            config
+                .license
+                .map(|license| format!("\nlicense = \"{license}\""))
+                .unwrap_or_default(),
             dependencies
                 .iter()
                 .map(|(name, value)| format!("{name} = {value}"))

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -368,5 +368,6 @@ primitive_impls!();
 
 #[cfg(feature = "generators")]
 pub use generators::{
-    generate_bindings, BindingConfig, BindingsType, RustPluginConfig, TsExtendedRuntimeConfig,
+    generate_bindings, BindingConfig, BindingsType, RustPluginConfig, RustPluginConfigValue,
+    TsExtendedRuntimeConfig,
 };

--- a/fp-bindgen/src/prelude.rs
+++ b/fp-bindgen/src/prelude.rs
@@ -3,5 +3,7 @@ pub use crate::primitives::Primitive;
 pub use crate::serializable::Serializable;
 pub use crate::types::{CustomType, Type, TypeIdent, TypeMap};
 #[cfg(feature = "generators")]
-pub use crate::{BindingConfig, BindingsType, RustPluginConfig, TsExtendedRuntimeConfig};
+pub use crate::{
+    BindingConfig, BindingsType, RustPluginConfig, RustPluginConfigValue, TsExtendedRuntimeConfig,
+};
 pub use fp_bindgen_macros::*;


### PR DESCRIPTION
This allows the `description` and `license` fields to be specified in `RustPluginConfig` and passed on to the generated `Cargo.toml`.