### PR TITLE
Fix erroneous unwrap in async export function

### DIFF
--- a/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_runtime/mod.rs
@@ -279,7 +279,7 @@ pub(crate) fn format_export_function(function: &Function, types: &TypeMap) -> St
         println!("Waiting for result...");
     let result = futures::executor::block_on(async {
         println!("Waiting for result...inside block_on");
-        let v = result.await.unwrap();
+        let v = result.await;
         println!("Waiting for result...after block_on");
         v
     });


### PR DESCRIPTION
The original code actually fails on this line if the guest function doesn't return an result, which is already fishy.

Removing the unwrap solves the problem.