### PR TITLE
Update rustfmt-wrapper

### DIFF
--- a/fp-bindgen/Cargo.toml
+++ b/fp-bindgen/Cargo.toml
@@ -45,4 +45,4 @@ serde_json = { version = "1.0", optional = true }
 syn = { version = "1", features = ["full", "extra-traits"] }
 time = { version = "0.3", features = ["serde-human-readable"], optional = true }
 toml_edit = { version = "0.19", optional = true }
-rustfmt-wrapper = { version = "0.1.0", optional = true }
+rustfmt-wrapper = { version = "0.2.0", optional = true }


### PR DESCRIPTION
There are 2 low severity CVEs ([1](https://cwe.mitre.org/data/definitions/366.html), [2](https://cwe.mitre.org/data/definitions/367.html)) in a package that `rustfmt-wrapper` depends upon. This pr resolves those.