### PR TITLE
Make primitive tests go back and forth, fix float params in imported functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Every field in the `RustPluginConfig` builder can be set to `RustPluginConfigValue::Workspace`
   to indicate the value in the generated `Cargo.toml` should come from the workspace instead.
 - Add `description`, `readme` and `license` fields to `RustPluginConfig`.
+- Changed primitive tests in example to go call imported functions from the plugin.
+
+### Fixed
+
+- Added workaround for imported functions with float arguments for wasmer2 in example,
+  see [#180](https://github.com/fiberplane/fp-bindgen/issues/180).
 
 ## [3.0.0-beta.1] - 2023-02-14
 

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -1,10 +1,12 @@
 import {
   assert,
-  assertAlmostEquals,
-  assertEquals, assertStrictEquals,
+  assertEquals,
+  assertStrictEquals,
 } from "https://deno.land/std@0.135.0/testing/asserts.ts";
-import { loadPlugin } from "./loader.ts";
-import type { Exports, Imports } from "../example-protocol/bindings/ts-runtime/index.ts";
+import type {
+  Exports,
+  Imports,
+} from "../example-protocol/bindings/ts-runtime/index.ts";
 import type {
   ExplicitBoundPoint,
   FpAdjacentlyTagged,
@@ -21,9 +23,11 @@ import type {
   SerdePropertyRenaming,
   SerdeUntagged,
   SerdeVariantRenaming,
-  StructWithGenerics, StructWithOptions,
+  StructWithGenerics,
+  StructWithOptions,
 } from "../example-protocol/bindings/ts-runtime/types.ts";
-import {Result} from "../example-protocol/bindings/ts-runtime/types.ts";
+import { Result } from "../example-protocol/bindings/ts-runtime/types.ts";
+import { loadPlugin } from "./loader.ts";
 
 let voidFunctionCalled = false;
 
@@ -68,28 +72,25 @@ const imports: Imports = {
   },
 
   importGenerics: (
-    arg: StructWithGenerics<number>,
+    arg: StructWithGenerics<number>
   ): StructWithGenerics<number> => {
-    assertEquals(
-      arg,
-      {
-        list: [0, 64],
-        points: [{ value: 64 }],
-        recursive: [{ value: { value: 64 } }],
-        complex_nested: {
-          "one": [{ value: 1.0 }],
-          "two": [{ value: 2.0 }],
-        },
-        optional_timestamp: "1970-01-01T00:00:00Z",
+    assertEquals(arg, {
+      list: [0, 64],
+      points: [{ value: 64 }],
+      recursive: [{ value: { value: 64 } }],
+      complex_nested: {
+        one: [{ value: 1.0 }],
+        two: [{ value: 2.0 }],
       },
-    );
+      optional_timestamp: "1970-01-01T00:00:00Z",
+    });
     return {
       list: [0, 64],
       points: [{ value: 64 }],
       recursive: [{ value: { value: 64 } }],
       complex_nested: {
-        "een": [{ value: 1.0 }],
-        "twee": [{ value: 2.0 }],
+        een: [{ value: 1.0 }],
+        twee: [{ value: 2.0 }],
       },
       optional_timestamp: "1970-01-01T00:00:00Z",
     };
@@ -204,7 +205,7 @@ const imports: Imports = {
   },
 
   importSerdeAdjacentlyTagged: (
-    arg: SerdeAdjacentlyTagged,
+    arg: SerdeAdjacentlyTagged
   ): SerdeAdjacentlyTagged => {
     assertEquals(arg, { type: "Bar", payload: "Hello, plugin!" });
     return { type: "Baz", payload: { a: -8, b: 64 } };
@@ -226,7 +227,7 @@ const imports: Imports = {
   },
 
   importSerdeInternallyTagged: (
-    arg: SerdeInternallyTagged,
+    arg: SerdeInternallyTagged
   ): SerdeInternallyTagged => {
     assertEquals(arg, { type: "Foo" });
     return { type: "Baz", a: -8, b: 64 };
@@ -258,12 +259,11 @@ const imports: Imports = {
 
   importVoidFunctionEmptyResult: (): Result<void, number> => {
     return {
-      Ok: undefined
+      Ok: undefined,
     };
   },
 
-  importVoidFunctionEmptyReturn: (): void => {
-  },
+  importVoidFunctionEmptyReturn: (): void => {},
 
   log: (message: string): void => {
     console.log("Plugin log: " + message);
@@ -278,15 +278,11 @@ const imports: Imports = {
       headers: {
         "content-type": encoder.encode("application/json"),
       },
-      body: encoder.encode(
-        JSON.stringify({ "country": "🇳🇱", "type": "sign-up" }),
-      ),
+      body: encoder.encode(JSON.stringify({ country: "🇳🇱", type: "sign-up" })),
     });
     return Promise.resolve({
       Ok: {
-        body: encoder.encode(
-          JSON.stringify({ "status": "confirmed" }),
-        ),
+        body: encoder.encode(JSON.stringify({ status: "confirmed" })),
         headers: {
           "content-type": encoder.encode("application/json"),
         },
@@ -303,7 +299,7 @@ const imports: Imports = {
     assertStrictEquals(arg.neverSkippedFilledOptionString, "Hello!");
     assertStrictEquals(arg.neverSkippedEmptyOptionString, null);
     return arg;
-  }
+  },
 };
 
 let examplePlugin: Exports | null = null;
@@ -311,7 +307,7 @@ async function loadExamplePlugin() {
   if (!examplePlugin) {
     examplePlugin = await loadPlugin(
       "../example-plugin/target/wasm32-unknown-unknown/debug/example_plugin.wasm",
-      imports,
+      imports
     );
 
     const { init } = examplePlugin;
@@ -325,22 +321,23 @@ async function loadExamplePlugin() {
 Deno.test("primitives", async () => {
   const plugin = await loadExamplePlugin();
 
-  assertEquals(plugin.exportPrimitiveBool?.(true), true);
-  assertEquals(plugin.exportPrimitiveBool?.(false), false);
+  assertEquals(plugin.exportPrimitiveBoolNegate?.(true), false);
+  assertEquals(plugin.exportPrimitiveBoolNegate?.(false), true);
 
-  assertEquals(plugin.exportPrimitiveU8?.(8), 8);
-  assertEquals(plugin.exportPrimitiveU16?.(16), 16);
-  assertEquals(plugin.exportPrimitiveU32?.(32), 32);
-  assertEquals(plugin.exportPrimitiveU64?.(64n), 64n);
-  assertEquals(plugin.exportPrimitiveI8?.(-8), -8);
-  assertEquals(plugin.exportPrimitiveI16?.(-16), -16);
-  assertEquals(plugin.exportPrimitiveI32?.(-32), -32);
-  assertEquals(plugin.exportPrimitiveI64?.(-64n), -64n);
+  assertEquals(plugin.exportPrimitiveU8AddThree?.(8), 8 + 3);
+  assertEquals(plugin.exportPrimitiveU16AddThree?.(16), 16 + 3);
+  assertEquals(plugin.exportPrimitiveU32AddThree?.(32), 32 + 3);
+  assertEquals(plugin.exportPrimitiveU64AddThree?.(64n), 64n + 3n);
+  assertEquals(plugin.exportPrimitiveI8AddThree?.(-8), -8 + 3);
+  assertEquals(plugin.exportPrimitiveI16AddThree?.(-16), -16 + 3);
+  assertEquals(plugin.exportPrimitiveI32AddThree?.(-32), -32 + 3);
+  assertEquals(plugin.exportPrimitiveI64AddThree?.(-64n), -64n + 3n);
 
   assertEquals(plugin.exportMultiplePrimitives?.(-8, "Hello, 🇳🇱!"), -64n);
 
-  assertAlmostEquals(plugin.exportPrimitiveF32?.(3.1415926535) ?? 0, 3.1415926535);
-  assertAlmostEquals(plugin.exportPrimitiveF64?.(2.718281828459) ?? 0, 2.718281828459);
+  // Precise float comparison is fine as long as the denominator is a power of two
+  assertEquals(plugin.exportPrimitiveF32AddThree?.(3.5), 3.5 + 3.0);
+  assertEquals(plugin.exportPrimitiveF64AddThree?.(2.5), 2.5 + 3.0);
 });
 
 Deno.test("arrays", async () => {
@@ -365,69 +362,81 @@ Deno.test("string", async () => {
 Deno.test("timestamp", async () => {
   const plugin = await loadExamplePlugin();
 
-  assertEquals(plugin.exportTimestamp?.("2022-04-12T19:10:00Z"), "2022-04-13T12:37:00Z");
+  assertEquals(
+    plugin.exportTimestamp?.("2022-04-12T19:10:00Z"),
+    "2022-04-13T12:37:00Z"
+  );
 });
 
 Deno.test("flattened structs", async () => {
   const plugin = await loadExamplePlugin();
 
-  assertEquals(plugin.exportFpStruct?.({
-    fooBar: "foo_bar",
-    QUX_BAZ: 64.0,
-    rawStruct: -32
-  }), {
-    fooBar: "fooBar",
-    QUX_BAZ: -64.0,
-    rawStruct: 32,
-  });
+  assertEquals(
+    plugin.exportFpStruct?.({
+      fooBar: "foo_bar",
+      QUX_BAZ: 64.0,
+      rawStruct: -32,
+    }),
+    {
+      fooBar: "fooBar",
+      QUX_BAZ: -64.0,
+      rawStruct: 32,
+    }
+  );
 
   assertEquals(plugin.exportFpEnum?.("foo_bar"), {
     QUX_BAZ: {
       FOO_BAR: "foo_bar",
       qux_baz: 64.0,
-    }
+    },
   });
 
-  assertEquals(plugin.exportSerdeStruct?.({
-    fooBar: "foo_bar",
-    QUX_BAZ: 64.0,
-    rawStruct: -32
-  }), {
-    fooBar: "fooBar",
-    QUX_BAZ: -64.0,
-    rawStruct: 32,
-  });
+  assertEquals(
+    plugin.exportSerdeStruct?.({
+      fooBar: "foo_bar",
+      QUX_BAZ: 64.0,
+      rawStruct: -32,
+    }),
+    {
+      fooBar: "fooBar",
+      QUX_BAZ: -64.0,
+      rawStruct: 32,
+    }
+  );
 
   assertEquals(plugin.exportSerdeEnum?.("foo_bar"), {
     QUX_BAZ: {
       FooBar: "foo_bar",
       qux_baz: 64.0,
-    }
+    },
   });
 });
 
 Deno.test("generics", async () => {
   const plugin = await loadExamplePlugin();
 
-  assertEquals(plugin.exportGenerics?.({
-    list: [0, 64],
-    points: [{ value: 64 }],
-    recursive: [{ value: { value: 64 } }],
-    complex_nested: {
-      "one": [{ value: 1.0 }],
-      "two": [{ value: 2.0 }],
-    },
-    optional_timestamp: "1970-01-01T00:00:00Z",
-  }), {
-    list: [0, 64],
-    points: [{ value: 64 }],
-    recursive: [{ value: { value: 64 } }],
-    complex_nested: {
-      "een": [{ value: 1.0 }],
-      "twee": [{ value: 2.0 }],
-    },
-    optional_timestamp: "1970-01-01T00:00:00Z",
-  });
+  assertEquals(
+    plugin.exportGenerics?.({
+      list: [0, 64],
+      points: [{ value: 64 }],
+      recursive: [{ value: { value: 64 } }],
+      complex_nested: {
+        one: [{ value: 1.0 }],
+        two: [{ value: 2.0 }],
+      },
+      optional_timestamp: "1970-01-01T00:00:00Z",
+    }),
+    {
+      list: [0, 64],
+      points: [{ value: 64 }],
+      recursive: [{ value: { value: 64 } }],
+      complex_nested: {
+        een: [{ value: 1.0 }],
+        twee: [{ value: 2.0 }],
+      },
+      optional_timestamp: "1970-01-01T00:00:00Z",
+    }
+  );
 });
 
 Deno.test("property renaming", async () => {
@@ -447,46 +456,67 @@ Deno.test("property renaming", async () => {
 Deno.test("tagged enums", async () => {
   const plugin = await loadExamplePlugin();
 
-  assertEquals(plugin.exportFpAdjacentlyTagged?.({ type: "Bar", payload: "Hello, plugin!" }), {
-    type: "Baz",
-    payload: { a: -8, b: 64 }
-  });
+  assertEquals(
+    plugin.exportFpAdjacentlyTagged?.({
+      type: "Bar",
+      payload: "Hello, plugin!",
+    }),
+    {
+      type: "Baz",
+      payload: { a: -8, b: 64 },
+    }
+  );
 
   assertEquals(plugin.exportFpInternallyTagged?.({ type: "Foo" }), {
     type: "Baz",
     a: -8,
-    b: 64
+    b: 64,
   });
 
   assertEquals(plugin.exportFpUntagged?.("Hello, plugin!"), { a: -8, b: 64 });
 
-  assertEquals(plugin.exportSerdeAdjacentlyTagged?.({ type: "Bar", payload: "Hello, plugin!" }), {
-    type: "Baz",
-    payload: { a: -8, b: 64 }
-  });
+  assertEquals(
+    plugin.exportSerdeAdjacentlyTagged?.({
+      type: "Bar",
+      payload: "Hello, plugin!",
+    }),
+    {
+      type: "Baz",
+      payload: { a: -8, b: 64 },
+    }
+  );
 
   assertEquals(plugin.exportSerdeInternallyTagged?.({ type: "Foo" }), {
     type: "Baz",
     a: -8,
-    b: 64
+    b: 64,
   });
 
-  assertEquals(plugin.exportSerdeUntagged?.("Hello, plugin!"), { a: -8, b: 64 });
+  assertEquals(plugin.exportSerdeUntagged?.("Hello, plugin!"), {
+    a: -8,
+    b: 64,
+  });
 });
 
 Deno.test("async struct", async () => {
   const { exportAsyncStruct } = await loadExamplePlugin();
   assert(exportAsyncStruct);
 
-  assertEquals(await exportAsyncStruct({
-    fooBar: "foo_bar",
-    QUX_BAZ: 64.0,
-    rawStruct: -32
-  }, 64n), {
-    fooBar: "fooBar",
-    QUX_BAZ: -64.0,
-    rawStruct: 32,
-  });
+  assertEquals(
+    await exportAsyncStruct(
+      {
+        fooBar: "foo_bar",
+        QUX_BAZ: 64.0,
+        rawStruct: -32,
+      },
+      64n
+    ),
+    {
+      fooBar: "fooBar",
+      QUX_BAZ: -64.0,
+      rawStruct: 32,
+    }
+  );
 });
 
 Deno.test("fetch async data", async () => {
@@ -495,7 +525,7 @@ Deno.test("fetch async data", async () => {
 
   const data = await fetchData("sign-up");
   assertEquals(data, {
-    Ok: JSON.stringify({ "status": "confirmed" })
+    Ok: JSON.stringify({ status: "confirmed" }),
   });
 });
 

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -122,6 +122,14 @@ const imports: Imports = {
     return arg + 1.0;
   },
 
+  importPrimitiveF32AddOneWasmer2: (arg: Float32Array): number => {
+    return arg[0] + 1.0;
+  },
+
+  importPrimitiveF64AddOneWasmer2: (arg: Float64Array): number => {
+    return arg[0] + 1.0;
+  },
+
   importPrimitiveI16AddOne: (arg: number): number => {
     return arg + 1;
   },
@@ -328,6 +336,10 @@ Deno.test("primitives", async () => {
   // Precise float comparison is fine as long as the denominator is a power of two
   assertEquals(plugin.exportPrimitiveF32AddThree?.(3.5), 3.5 + 3.0);
   assertEquals(plugin.exportPrimitiveF64AddThree?.(2.5), 2.5 + 3.0);
+
+  // We need to define the workarounf methods for wasmer2, so we might as well test them
+  assertEquals(plugin.exportPrimitiveF32AddThreeWasmer2?.(13.5), 13.5 + 3.0);
+  assertEquals(plugin.exportPrimitiveF64AddThreeWasmer2?.(12.5), 12.5 + 3.0);
 });
 
 Deno.test("arrays", async () => {

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -110,58 +110,48 @@ const imports: Imports = {
     return -64n;
   },
 
-  importPrimitiveBool: (arg: boolean): boolean => {
-    return arg;
+  importPrimitiveBoolNegate: (arg: boolean): boolean => {
+    return !arg;
   },
 
-  importPrimitiveF32: (arg: number): number => {
-    assertAlmostEquals(arg, 3.1415926535);
-    return 3.1415926535;
+  importPrimitiveF32AddOne: (arg: number): number => {
+    return arg + 1.0;
   },
 
-  importPrimitiveF64: (arg: number): number => {
-    assertAlmostEquals(arg, 2.718281828459);
-    return 2.718281828459;
+  importPrimitiveF64AddOne: (arg: number): number => {
+    return arg + 1.0;
   },
 
-  importPrimitiveI16: (arg: number): number => {
-    assertEquals(arg, -16);
-    return -16;
+  importPrimitiveI16AddOne: (arg: number): number => {
+    return arg + 1;
   },
 
-  importPrimitiveI32: (arg: number): number => {
-    assertEquals(arg, -32);
-    return -32;
+  importPrimitiveI32AddOne: (arg: number): number => {
+    return arg + 1;
   },
 
-  importPrimitiveI64: (arg: bigint): bigint => {
-    assertEquals(arg, -64n);
-    return -64n;
+  importPrimitiveI64AddOne: (arg: bigint): bigint => {
+    return arg + 1n;
   },
 
-  importPrimitiveI8: (arg: number): number => {
-    assertEquals(arg, -8);
-    return -8;
+  importPrimitiveI8AddOne: (arg: number): number => {
+    return arg + 1;
   },
 
-  importPrimitiveU16: (arg: number): number => {
-    assertEquals(arg, 16);
-    return 16;
+  importPrimitiveU16AddOne: (arg: number): number => {
+    return arg + 1;
   },
 
-  importPrimitiveU32: (arg: number): number => {
-    assertEquals(arg, 32);
-    return 32;
+  importPrimitiveU32AddOne: (arg: number): number => {
+    return arg + 1;
   },
 
-  importPrimitiveU64: (arg: bigint): bigint => {
-    assertEquals(arg, 64n);
-    return 64n;
+  importPrimitiveU64AddOne: (arg: bigint): bigint => {
+    return arg + 1n;
   },
 
-  importPrimitiveU8: (arg: number): number => {
-    assertEquals(arg, 8);
-    return 8;
+  importPrimitiveU8AddOne: (arg: number): number => {
+    return arg + 1;
   },
 
   importArrayU8: (arg: Uint8Array): Uint8Array => {

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -28,70 +28,58 @@ fn init_panic_hook() {
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_bool(arg: bool) -> bool {
-    arg
+fn export_primitive_bool_negate(arg: bool) -> bool {
+    !import_primitive_bool_negate(!arg)
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_f32(arg: f32) -> f32 {
-    assert!(arg > 3.14);
-    assert!(arg < 3.15);
-    3.1415926535
+fn export_primitive_f32_add_three(arg: f32) -> f32 {
+    import_primitive_f32_add_one(arg + 1.0) + 1.0
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_f64(arg: f64) -> f64 {
-    assert!(arg > 2.7182);
-    assert!(arg < 2.7183);
-    2.718281828459
+fn export_primitive_f64_add_three(arg: f64) -> f64 {
+    import_primitive_f64_add_one(arg + 1.0) + 1.0
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_i8(arg: i8) -> i8 {
-    assert_eq!(arg, -8);
-    -8
+fn export_primitive_i8_add_three(arg: i8) -> i8 {
+    import_primitive_i8_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_i16(arg: i16) -> i16 {
-    assert_eq!(arg, -16);
-    -16
+fn export_primitive_i16_add_three(arg: i16) -> i16 {
+    import_primitive_i16_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_i32(arg: i32) -> i32 {
-    assert_eq!(arg, -32);
-    -32
+fn export_primitive_i32_add_three(arg: i32) -> i32 {
+    import_primitive_i32_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_i64(arg: i64) -> i64 {
-    assert_eq!(arg, -64);
-    -64
+fn export_primitive_i64_add_three(arg: i64) -> i64 {
+    import_primitive_i64_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_u8(arg: u8) -> u8 {
-    assert_eq!(arg, 8);
-    8
+fn export_primitive_u8_add_three(arg: u8) -> u8 {
+    import_primitive_u8_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_u16(arg: u16) -> u16 {
-    assert_eq!(arg, 16);
-    16
+fn export_primitive_u16_add_three(arg: u16) -> u16 {
+    import_primitive_u16_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_u32(arg: u32) -> u32 {
-    assert_eq!(arg, 32);
-    32
+fn export_primitive_u32_add_three(arg: u32) -> u32 {
+    import_primitive_u32_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]
-fn export_primitive_u64(arg: u64) -> u64 {
-    assert_eq!(arg, 64);
-    64
+fn export_primitive_u64_add_three(arg: u64) -> u64 {
+    import_primitive_u64_add_one(arg + 1) + 1
 }
 
 #[fp_export_impl(example_bindings)]

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -34,12 +34,12 @@ fn export_primitive_bool_negate(arg: bool) -> bool {
 
 #[fp_export_impl(example_bindings)]
 fn export_primitive_f32_add_three(arg: f32) -> f32 {
-    import_primitive_f32_add_one(arg + 1.0) + 1.0
+    import_primitive_f32_add_one([arg + 1.0]) + 1.0
 }
 
 #[fp_export_impl(example_bindings)]
 fn export_primitive_f64_add_three(arg: f64) -> f64 {
-    import_primitive_f64_add_one(arg + 1.0) + 1.0
+    import_primitive_f64_add_one([arg + 1.0]) + 1.0
 }
 
 #[fp_export_impl(example_bindings)]

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -34,12 +34,23 @@ fn export_primitive_bool_negate(arg: bool) -> bool {
 
 #[fp_export_impl(example_bindings)]
 fn export_primitive_f32_add_three(arg: f32) -> f32 {
-    import_primitive_f32_add_one([arg + 1.0]) + 1.0
+    import_primitive_f32_add_one(arg + 1.0) + 1.0
 }
 
 #[fp_export_impl(example_bindings)]
 fn export_primitive_f64_add_three(arg: f64) -> f64 {
-    import_primitive_f64_add_one([arg + 1.0]) + 1.0
+    import_primitive_f64_add_one(arg + 1.0) + 1.0
+}
+
+// Workaround for wasmer2
+#[fp_export_impl(example_bindings)]
+fn export_primitive_f32_add_three_wasmer2(arg: f32) -> f32 {
+    import_primitive_f32_add_one_wasmer2([arg + 1.0]) + 1.0
+}
+
+#[fp_export_impl(example_bindings)]
+fn export_primitive_f64_add_three_wasmer2(arg: f64) -> f64 {
+    import_primitive_f64_add_one_wasmer2([arg + 1.0]) + 1.0
 }
 
 #[fp_export_impl(example_bindings)]

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
@@ -58,37 +58,43 @@ pub fn export_get_serde_bytes() -> Result<serde_bytes::ByteBuf, String>;
 pub fn export_multiple_primitives(arg1: i8, arg2: String) -> i64;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_bool(arg: bool) -> bool;
+pub fn export_primitive_bool_negate(arg: bool) -> bool;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_f32(arg: f32) -> f32;
+pub fn export_primitive_f32_add_three(arg: f32) -> f32;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_f64(arg: f64) -> f64;
+pub fn export_primitive_f32_add_three_wasmer2(arg: f32) -> f32;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_i16(arg: i16) -> i16;
+pub fn export_primitive_f64_add_three(arg: f64) -> f64;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_i32(arg: i32) -> i32;
+pub fn export_primitive_f64_add_three_wasmer2(arg: f64) -> f64;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_i64(arg: i64) -> i64;
+pub fn export_primitive_i16_add_three(arg: i16) -> i16;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_i8(arg: i8) -> i8;
+pub fn export_primitive_i32_add_three(arg: i32) -> i32;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_u16(arg: u16) -> u16;
+pub fn export_primitive_i64_add_three(arg: i64) -> i64;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_u32(arg: u32) -> u32;
+pub fn export_primitive_i8_add_three(arg: i8) -> i8;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_u64(arg: u64) -> u64;
+pub fn export_primitive_u16_add_three(arg: u16) -> u16;
 
 #[fp_bindgen_support::fp_export_signature]
-pub fn export_primitive_u8(arg: u8) -> u8;
+pub fn export_primitive_u32_add_three(arg: u32) -> u32;
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_primitive_u64_add_three(arg: u64) -> u64;
+
+#[fp_bindgen_support::fp_export_signature]
+pub fn export_primitive_u8_add_three(arg: u8) -> u8;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_serde_adjacently_tagged(arg: SerdeAdjacentlyTagged) -> SerdeAdjacentlyTagged;

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -58,37 +58,43 @@ pub fn import_get_serde_bytes() -> Result<serde_bytes::ByteBuf, String>;
 pub fn import_multiple_primitives(arg1: i8, arg2: String) -> i64;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_bool(arg: bool) -> bool;
+pub fn import_primitive_bool_negate(arg: bool) -> bool;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_f32(arg: f32) -> f32;
+pub fn import_primitive_f32_add_one(arg: f32) -> f32;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_f64(arg: f64) -> f64;
+pub fn import_primitive_f32_add_one_wasmer2(arg: [f32; 1]) -> f32;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_i16(arg: i16) -> i16;
+pub fn import_primitive_f64_add_one(arg: f64) -> f64;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_i32(arg: i32) -> i32;
+pub fn import_primitive_f64_add_one_wasmer2(arg: [f64; 1]) -> f64;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_i64(arg: i64) -> i64;
+pub fn import_primitive_i16_add_one(arg: i16) -> i16;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_i8(arg: i8) -> i8;
+pub fn import_primitive_i32_add_one(arg: i32) -> i32;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_u16(arg: u16) -> u16;
+pub fn import_primitive_i64_add_one(arg: i64) -> i64;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_u32(arg: u32) -> u32;
+pub fn import_primitive_i8_add_one(arg: i8) -> i8;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_u64(arg: u64) -> u64;
+pub fn import_primitive_u16_add_one(arg: u16) -> u16;
 
 #[fp_bindgen_support::fp_import_signature]
-pub fn import_primitive_u8(arg: u8) -> u8;
+pub fn import_primitive_u32_add_one(arg: u32) -> u32;
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_primitive_u64_add_one(arg: u64) -> u64;
+
+#[fp_bindgen_support::fp_import_signature]
+pub fn import_primitive_u8_add_one(arg: u8) -> u8;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_serde_adjacently_tagged(arg: SerdeAdjacentlyTagged) -> SerdeAdjacentlyTagged;

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -470,209 +470,279 @@ impl Runtime {
         Ok(result)
     }
 
-    pub fn export_primitive_bool(&self, arg: bool) -> Result<bool, InvocationError> {
-        let result = self.export_primitive_bool_raw(arg);
+    pub fn export_primitive_bool_negate(&self, arg: bool) -> Result<bool, InvocationError> {
+        let result = self.export_primitive_bool_negate_raw(arg);
         result
     }
-    pub fn export_primitive_bool_raw(&self, arg: bool) -> Result<bool, InvocationError> {
+    pub fn export_primitive_bool_negate_raw(&self, arg: bool) -> Result<bool, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_bool",
+                "__fp_gen_export_primitive_bool_negate",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_bool".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_bool_negate".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_f32(&self, arg: f32) -> Result<f32, InvocationError> {
-        let result = self.export_primitive_f32_raw(arg);
+    pub fn export_primitive_f32_add_three(&self, arg: f32) -> Result<f32, InvocationError> {
+        let result = self.export_primitive_f32_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_f32_raw(&self, arg: f32) -> Result<f32, InvocationError> {
+    pub fn export_primitive_f32_add_three_raw(&self, arg: f32) -> Result<f32, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_f32",
+                "__fp_gen_export_primitive_f32_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_f32".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f32_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_f64(&self, arg: f64) -> Result<f64, InvocationError> {
-        let result = self.export_primitive_f64_raw(arg);
+    pub fn export_primitive_f32_add_three_wasmer2(&self, arg: f32) -> Result<f32, InvocationError> {
+        let result = self.export_primitive_f32_add_three_wasmer2_raw(arg);
         result
     }
-    pub fn export_primitive_f64_raw(&self, arg: f64) -> Result<f64, InvocationError> {
+    pub fn export_primitive_f32_add_three_wasmer2_raw(
+        &self,
+        arg: f32,
+    ) -> Result<f32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f32_add_three_wasmer2",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f32_add_three_wasmer2".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub fn export_primitive_f64_add_three(&self, arg: f64) -> Result<f64, InvocationError> {
+        let result = self.export_primitive_f64_add_three_raw(arg);
+        result
+    }
+    pub fn export_primitive_f64_add_three_raw(&self, arg: f64) -> Result<f64, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_f64",
+                "__fp_gen_export_primitive_f64_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_f64".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f64_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i16(&self, arg: i16) -> Result<i16, InvocationError> {
-        let result = self.export_primitive_i16_raw(arg);
+    pub fn export_primitive_f64_add_three_wasmer2(&self, arg: f64) -> Result<f64, InvocationError> {
+        let result = self.export_primitive_f64_add_three_wasmer2_raw(arg);
         result
     }
-    pub fn export_primitive_i16_raw(&self, arg: i16) -> Result<i16, InvocationError> {
+    pub fn export_primitive_f64_add_three_wasmer2_raw(
+        &self,
+        arg: f64,
+    ) -> Result<f64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f64_add_three_wasmer2",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f64_add_three_wasmer2".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub fn export_primitive_i16_add_three(&self, arg: i16) -> Result<i16, InvocationError> {
+        let result = self.export_primitive_i16_add_three_raw(arg);
+        result
+    }
+    pub fn export_primitive_i16_add_three_raw(&self, arg: i16) -> Result<i16, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i16",
+                "__fp_gen_export_primitive_i16_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i16".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i16_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i32(&self, arg: i32) -> Result<i32, InvocationError> {
-        let result = self.export_primitive_i32_raw(arg);
+    pub fn export_primitive_i32_add_three(&self, arg: i32) -> Result<i32, InvocationError> {
+        let result = self.export_primitive_i32_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_i32_raw(&self, arg: i32) -> Result<i32, InvocationError> {
+    pub fn export_primitive_i32_add_three_raw(&self, arg: i32) -> Result<i32, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i32",
+                "__fp_gen_export_primitive_i32_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i32".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i32_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i64(&self, arg: i64) -> Result<i64, InvocationError> {
-        let result = self.export_primitive_i64_raw(arg);
+    pub fn export_primitive_i64_add_three(&self, arg: i64) -> Result<i64, InvocationError> {
+        let result = self.export_primitive_i64_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_i64_raw(&self, arg: i64) -> Result<i64, InvocationError> {
+    pub fn export_primitive_i64_add_three_raw(&self, arg: i64) -> Result<i64, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i64",
+                "__fp_gen_export_primitive_i64_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i64".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i64_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i8(&self, arg: i8) -> Result<i8, InvocationError> {
-        let result = self.export_primitive_i8_raw(arg);
+    pub fn export_primitive_i8_add_three(&self, arg: i8) -> Result<i8, InvocationError> {
+        let result = self.export_primitive_i8_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_i8_raw(&self, arg: i8) -> Result<i8, InvocationError> {
+    pub fn export_primitive_i8_add_three_raw(&self, arg: i8) -> Result<i8, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i8",
+                "__fp_gen_export_primitive_i8_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i8".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i8_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u16(&self, arg: u16) -> Result<u16, InvocationError> {
-        let result = self.export_primitive_u16_raw(arg);
+    pub fn export_primitive_u16_add_three(&self, arg: u16) -> Result<u16, InvocationError> {
+        let result = self.export_primitive_u16_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u16_raw(&self, arg: u16) -> Result<u16, InvocationError> {
+    pub fn export_primitive_u16_add_three_raw(&self, arg: u16) -> Result<u16, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u16",
+                "__fp_gen_export_primitive_u16_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u16".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u16_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u32(&self, arg: u32) -> Result<u32, InvocationError> {
-        let result = self.export_primitive_u32_raw(arg);
+    pub fn export_primitive_u32_add_three(&self, arg: u32) -> Result<u32, InvocationError> {
+        let result = self.export_primitive_u32_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u32_raw(&self, arg: u32) -> Result<u32, InvocationError> {
+    pub fn export_primitive_u32_add_three_raw(&self, arg: u32) -> Result<u32, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u32",
+                "__fp_gen_export_primitive_u32_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u32".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u32_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u64(&self, arg: u64) -> Result<u64, InvocationError> {
-        let result = self.export_primitive_u64_raw(arg);
+    pub fn export_primitive_u64_add_three(&self, arg: u64) -> Result<u64, InvocationError> {
+        let result = self.export_primitive_u64_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u64_raw(&self, arg: u64) -> Result<u64, InvocationError> {
+    pub fn export_primitive_u64_add_three_raw(&self, arg: u64) -> Result<u64, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u64",
+                "__fp_gen_export_primitive_u64_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u64".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u64_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u8(&self, arg: u8) -> Result<u8, InvocationError> {
-        let result = self.export_primitive_u8_raw(arg);
+    pub fn export_primitive_u8_add_three(&self, arg: u8) -> Result<u8, InvocationError> {
+        let result = self.export_primitive_u8_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u8_raw(&self, arg: u8) -> Result<u8, InvocationError> {
+    pub fn export_primitive_u8_add_three_raw(&self, arg: u8) -> Result<u8, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u8",
+                "__fp_gen_export_primitive_u8_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u8".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u8_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
@@ -990,17 +1060,19 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
             "__fp_gen_import_get_bytes" => Function::new_native_with_env(store, env.clone(), _import_get_bytes),
             "__fp_gen_import_get_serde_bytes" => Function::new_native_with_env(store, env.clone(), _import_get_serde_bytes),
             "__fp_gen_import_multiple_primitives" => Function::new_native_with_env(store, env.clone(), _import_multiple_primitives),
-            "__fp_gen_import_primitive_bool" => Function::new_native_with_env(store, env.clone(), _import_primitive_bool),
-            "__fp_gen_import_primitive_f32" => Function::new_native_with_env(store, env.clone(), _import_primitive_f32),
-            "__fp_gen_import_primitive_f64" => Function::new_native_with_env(store, env.clone(), _import_primitive_f64),
-            "__fp_gen_import_primitive_i16" => Function::new_native_with_env(store, env.clone(), _import_primitive_i16),
-            "__fp_gen_import_primitive_i32" => Function::new_native_with_env(store, env.clone(), _import_primitive_i32),
-            "__fp_gen_import_primitive_i64" => Function::new_native_with_env(store, env.clone(), _import_primitive_i64),
-            "__fp_gen_import_primitive_i8" => Function::new_native_with_env(store, env.clone(), _import_primitive_i8),
-            "__fp_gen_import_primitive_u16" => Function::new_native_with_env(store, env.clone(), _import_primitive_u16),
-            "__fp_gen_import_primitive_u32" => Function::new_native_with_env(store, env.clone(), _import_primitive_u32),
-            "__fp_gen_import_primitive_u64" => Function::new_native_with_env(store, env.clone(), _import_primitive_u64),
-            "__fp_gen_import_primitive_u8" => Function::new_native_with_env(store, env.clone(), _import_primitive_u8),
+            "__fp_gen_import_primitive_bool_negate" => Function::new_native_with_env(store, env.clone(), _import_primitive_bool_negate),
+            "__fp_gen_import_primitive_f32_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one),
+            "__fp_gen_import_primitive_f32_add_one_wasmer2" => Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one_wasmer2),
+            "__fp_gen_import_primitive_f64_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one),
+            "__fp_gen_import_primitive_f64_add_one_wasmer2" => Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one_wasmer2),
+            "__fp_gen_import_primitive_i16_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i16_add_one),
+            "__fp_gen_import_primitive_i32_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i32_add_one),
+            "__fp_gen_import_primitive_i64_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i64_add_one),
+            "__fp_gen_import_primitive_i8_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i8_add_one),
+            "__fp_gen_import_primitive_u16_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u16_add_one),
+            "__fp_gen_import_primitive_u32_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u32_add_one),
+            "__fp_gen_import_primitive_u64_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u64_add_one),
+            "__fp_gen_import_primitive_u8_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u8_add_one),
             "__fp_gen_import_serde_adjacently_tagged" => Function::new_native_with_env(store, env.clone(), _import_serde_adjacently_tagged),
             "__fp_gen_import_serde_enum" => Function::new_native_with_env(store, env.clone(), _import_serde_enum),
             "__fp_gen_import_serde_flatten" => Function::new_native_with_env(store, env.clone(), _import_serde_flatten),
@@ -1135,102 +1207,120 @@ pub fn _import_multiple_primitives(
     result.to_abi()
 }
 
-pub fn _import_primitive_bool(
+pub fn _import_primitive_bool_negate(
     env: &RuntimeInstanceData,
     arg: <bool as WasmAbi>::AbiType,
 ) -> <bool as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_bool(arg);
+    let result = super::import_primitive_bool_negate(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_f32(
+pub fn _import_primitive_f32_add_one(
     env: &RuntimeInstanceData,
     arg: <f32 as WasmAbi>::AbiType,
 ) -> <f32 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_f32(arg);
+    let result = super::import_primitive_f32_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_f64(
+pub fn _import_primitive_f32_add_one_wasmer2(
+    env: &RuntimeInstanceData,
+    arg: FatPtr,
+) -> <f32 as WasmAbi>::AbiType {
+    let arg = import_from_guest::<[f32; 1]>(env, arg);
+    let result = super::import_primitive_f32_add_one_wasmer2(arg);
+    result.to_abi()
+}
+
+pub fn _import_primitive_f64_add_one(
     env: &RuntimeInstanceData,
     arg: <f64 as WasmAbi>::AbiType,
 ) -> <f64 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_f64(arg);
+    let result = super::import_primitive_f64_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i16(
+pub fn _import_primitive_f64_add_one_wasmer2(
+    env: &RuntimeInstanceData,
+    arg: FatPtr,
+) -> <f64 as WasmAbi>::AbiType {
+    let arg = import_from_guest::<[f64; 1]>(env, arg);
+    let result = super::import_primitive_f64_add_one_wasmer2(arg);
+    result.to_abi()
+}
+
+pub fn _import_primitive_i16_add_one(
     env: &RuntimeInstanceData,
     arg: <i16 as WasmAbi>::AbiType,
 ) -> <i16 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i16(arg);
+    let result = super::import_primitive_i16_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i32(
+pub fn _import_primitive_i32_add_one(
     env: &RuntimeInstanceData,
     arg: <i32 as WasmAbi>::AbiType,
 ) -> <i32 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i32(arg);
+    let result = super::import_primitive_i32_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i64(
+pub fn _import_primitive_i64_add_one(
     env: &RuntimeInstanceData,
     arg: <i64 as WasmAbi>::AbiType,
 ) -> <i64 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i64(arg);
+    let result = super::import_primitive_i64_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i8(
+pub fn _import_primitive_i8_add_one(
     env: &RuntimeInstanceData,
     arg: <i8 as WasmAbi>::AbiType,
 ) -> <i8 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i8(arg);
+    let result = super::import_primitive_i8_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u16(
+pub fn _import_primitive_u16_add_one(
     env: &RuntimeInstanceData,
     arg: <u16 as WasmAbi>::AbiType,
 ) -> <u16 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u16(arg);
+    let result = super::import_primitive_u16_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u32(
+pub fn _import_primitive_u32_add_one(
     env: &RuntimeInstanceData,
     arg: <u32 as WasmAbi>::AbiType,
 ) -> <u32 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u32(arg);
+    let result = super::import_primitive_u32_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u64(
+pub fn _import_primitive_u64_add_one(
     env: &RuntimeInstanceData,
     arg: <u64 as WasmAbi>::AbiType,
 ) -> <u64 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u64(arg);
+    let result = super::import_primitive_u64_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u8(
+pub fn _import_primitive_u8_add_one(
     env: &RuntimeInstanceData,
     arg: <u8 as WasmAbi>::AbiType,
 ) -> <u8 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u8(arg);
+    let result = super::import_primitive_u8_add_one(arg);
     result.to_abi()
 }
 

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -473,209 +473,279 @@ impl Runtime {
         Ok(result)
     }
 
-    pub fn export_primitive_bool(&self, arg: bool) -> Result<bool, InvocationError> {
-        let result = self.export_primitive_bool_raw(arg);
+    pub fn export_primitive_bool_negate(&self, arg: bool) -> Result<bool, InvocationError> {
+        let result = self.export_primitive_bool_negate_raw(arg);
         result
     }
-    pub fn export_primitive_bool_raw(&self, arg: bool) -> Result<bool, InvocationError> {
+    pub fn export_primitive_bool_negate_raw(&self, arg: bool) -> Result<bool, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_bool",
+                "__fp_gen_export_primitive_bool_negate",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_bool".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_bool_negate".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_f32(&self, arg: f32) -> Result<f32, InvocationError> {
-        let result = self.export_primitive_f32_raw(arg);
+    pub fn export_primitive_f32_add_three(&self, arg: f32) -> Result<f32, InvocationError> {
+        let result = self.export_primitive_f32_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_f32_raw(&self, arg: f32) -> Result<f32, InvocationError> {
+    pub fn export_primitive_f32_add_three_raw(&self, arg: f32) -> Result<f32, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_f32",
+                "__fp_gen_export_primitive_f32_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_f32".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f32_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_f64(&self, arg: f64) -> Result<f64, InvocationError> {
-        let result = self.export_primitive_f64_raw(arg);
+    pub fn export_primitive_f32_add_three_wasmer2(&self, arg: f32) -> Result<f32, InvocationError> {
+        let result = self.export_primitive_f32_add_three_wasmer2_raw(arg);
         result
     }
-    pub fn export_primitive_f64_raw(&self, arg: f64) -> Result<f64, InvocationError> {
+    pub fn export_primitive_f32_add_three_wasmer2_raw(
+        &self,
+        arg: f32,
+    ) -> Result<f32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f32_add_three_wasmer2",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f32_add_three_wasmer2".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub fn export_primitive_f64_add_three(&self, arg: f64) -> Result<f64, InvocationError> {
+        let result = self.export_primitive_f64_add_three_raw(arg);
+        result
+    }
+    pub fn export_primitive_f64_add_three_raw(&self, arg: f64) -> Result<f64, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_f64",
+                "__fp_gen_export_primitive_f64_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_f64".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f64_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i16(&self, arg: i16) -> Result<i16, InvocationError> {
-        let result = self.export_primitive_i16_raw(arg);
+    pub fn export_primitive_f64_add_three_wasmer2(&self, arg: f64) -> Result<f64, InvocationError> {
+        let result = self.export_primitive_f64_add_three_wasmer2_raw(arg);
         result
     }
-    pub fn export_primitive_i16_raw(&self, arg: i16) -> Result<i16, InvocationError> {
+    pub fn export_primitive_f64_add_three_wasmer2_raw(
+        &self,
+        arg: f64,
+    ) -> Result<f64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f64_add_three_wasmer2",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f64_add_three_wasmer2".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub fn export_primitive_i16_add_three(&self, arg: i16) -> Result<i16, InvocationError> {
+        let result = self.export_primitive_i16_add_three_raw(arg);
+        result
+    }
+    pub fn export_primitive_i16_add_three_raw(&self, arg: i16) -> Result<i16, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i16",
+                "__fp_gen_export_primitive_i16_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i16".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i16_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i32(&self, arg: i32) -> Result<i32, InvocationError> {
-        let result = self.export_primitive_i32_raw(arg);
+    pub fn export_primitive_i32_add_three(&self, arg: i32) -> Result<i32, InvocationError> {
+        let result = self.export_primitive_i32_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_i32_raw(&self, arg: i32) -> Result<i32, InvocationError> {
+    pub fn export_primitive_i32_add_three_raw(&self, arg: i32) -> Result<i32, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i32",
+                "__fp_gen_export_primitive_i32_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i32".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i32_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i64(&self, arg: i64) -> Result<i64, InvocationError> {
-        let result = self.export_primitive_i64_raw(arg);
+    pub fn export_primitive_i64_add_three(&self, arg: i64) -> Result<i64, InvocationError> {
+        let result = self.export_primitive_i64_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_i64_raw(&self, arg: i64) -> Result<i64, InvocationError> {
+    pub fn export_primitive_i64_add_three_raw(&self, arg: i64) -> Result<i64, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i64",
+                "__fp_gen_export_primitive_i64_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i64".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i64_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_i8(&self, arg: i8) -> Result<i8, InvocationError> {
-        let result = self.export_primitive_i8_raw(arg);
+    pub fn export_primitive_i8_add_three(&self, arg: i8) -> Result<i8, InvocationError> {
+        let result = self.export_primitive_i8_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_i8_raw(&self, arg: i8) -> Result<i8, InvocationError> {
+    pub fn export_primitive_i8_add_three_raw(&self, arg: i8) -> Result<i8, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_i8",
+                "__fp_gen_export_primitive_i8_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_i8".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i8_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u16(&self, arg: u16) -> Result<u16, InvocationError> {
-        let result = self.export_primitive_u16_raw(arg);
+    pub fn export_primitive_u16_add_three(&self, arg: u16) -> Result<u16, InvocationError> {
+        let result = self.export_primitive_u16_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u16_raw(&self, arg: u16) -> Result<u16, InvocationError> {
+    pub fn export_primitive_u16_add_three_raw(&self, arg: u16) -> Result<u16, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u16",
+                "__fp_gen_export_primitive_u16_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u16".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u16_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u32(&self, arg: u32) -> Result<u32, InvocationError> {
-        let result = self.export_primitive_u32_raw(arg);
+    pub fn export_primitive_u32_add_three(&self, arg: u32) -> Result<u32, InvocationError> {
+        let result = self.export_primitive_u32_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u32_raw(&self, arg: u32) -> Result<u32, InvocationError> {
+    pub fn export_primitive_u32_add_three_raw(&self, arg: u32) -> Result<u32, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u32",
+                "__fp_gen_export_primitive_u32_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u32".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u32_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u64(&self, arg: u64) -> Result<u64, InvocationError> {
-        let result = self.export_primitive_u64_raw(arg);
+    pub fn export_primitive_u64_add_three(&self, arg: u64) -> Result<u64, InvocationError> {
+        let result = self.export_primitive_u64_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u64_raw(&self, arg: u64) -> Result<u64, InvocationError> {
+    pub fn export_primitive_u64_add_three_raw(&self, arg: u64) -> Result<u64, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u64",
+                "__fp_gen_export_primitive_u64_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u64".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u64_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
         Ok(result)
     }
 
-    pub fn export_primitive_u8(&self, arg: u8) -> Result<u8, InvocationError> {
-        let result = self.export_primitive_u8_raw(arg);
+    pub fn export_primitive_u8_add_three(&self, arg: u8) -> Result<u8, InvocationError> {
+        let result = self.export_primitive_u8_add_three_raw(arg);
         result
     }
-    pub fn export_primitive_u8_raw(&self, arg: u8) -> Result<u8, InvocationError> {
+    pub fn export_primitive_u8_add_three_raw(&self, arg: u8) -> Result<u8, InvocationError> {
         let function = self
             .instance
             .exports
             .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
-                "__fp_gen_export_primitive_u8",
+                "__fp_gen_export_primitive_u8_add_three",
             )
             .map_err(|_| {
-                InvocationError::FunctionNotExported("__fp_gen_export_primitive_u8".to_owned())
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u8_add_three".to_owned(),
+                )
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
@@ -1053,48 +1123,56 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> wasmer::Exp
         Function::new_native_with_env(store, env.clone(), _import_multiple_primitives),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_bool",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_bool),
+        "__fp_gen_import_primitive_bool_negate",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_bool_negate),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_f32",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_f32),
+        "__fp_gen_import_primitive_f32_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_f64",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_f64),
+        "__fp_gen_import_primitive_f32_add_one_wasmer2",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one_wasmer2),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_i16",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_i16),
+        "__fp_gen_import_primitive_f64_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_i32",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_i32),
+        "__fp_gen_import_primitive_f64_add_one_wasmer2",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one_wasmer2),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_i64",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_i64),
+        "__fp_gen_import_primitive_i16_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i16_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_i8",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_i8),
+        "__fp_gen_import_primitive_i32_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i32_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_u16",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_u16),
+        "__fp_gen_import_primitive_i64_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i64_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_u32",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_u32),
+        "__fp_gen_import_primitive_i8_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i8_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_u64",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_u64),
+        "__fp_gen_import_primitive_u16_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u16_add_one),
     );
     namespace.insert(
-        "__fp_gen_import_primitive_u8",
-        Function::new_native_with_env(store, env.clone(), _import_primitive_u8),
+        "__fp_gen_import_primitive_u32_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u32_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_u64_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u64_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_u8_add_one",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u8_add_one),
     );
     namespace.insert(
         "__fp_gen_import_serde_adjacently_tagged",
@@ -1271,102 +1349,120 @@ pub fn _import_multiple_primitives(
     result.to_abi()
 }
 
-pub fn _import_primitive_bool(
+pub fn _import_primitive_bool_negate(
     env: &RuntimeInstanceData,
     arg: <bool as WasmAbi>::AbiType,
 ) -> <bool as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_bool(arg);
+    let result = super::import_primitive_bool_negate(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_f32(
+pub fn _import_primitive_f32_add_one(
     env: &RuntimeInstanceData,
     arg: <f32 as WasmAbi>::AbiType,
 ) -> <f32 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_f32(arg);
+    let result = super::import_primitive_f32_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_f64(
+pub fn _import_primitive_f32_add_one_wasmer2(
+    env: &RuntimeInstanceData,
+    arg: FatPtr,
+) -> <f32 as WasmAbi>::AbiType {
+    let arg = import_from_guest::<[f32; 1]>(env, arg);
+    let result = super::import_primitive_f32_add_one_wasmer2(arg);
+    result.to_abi()
+}
+
+pub fn _import_primitive_f64_add_one(
     env: &RuntimeInstanceData,
     arg: <f64 as WasmAbi>::AbiType,
 ) -> <f64 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_f64(arg);
+    let result = super::import_primitive_f64_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i16(
+pub fn _import_primitive_f64_add_one_wasmer2(
+    env: &RuntimeInstanceData,
+    arg: FatPtr,
+) -> <f64 as WasmAbi>::AbiType {
+    let arg = import_from_guest::<[f64; 1]>(env, arg);
+    let result = super::import_primitive_f64_add_one_wasmer2(arg);
+    result.to_abi()
+}
+
+pub fn _import_primitive_i16_add_one(
     env: &RuntimeInstanceData,
     arg: <i16 as WasmAbi>::AbiType,
 ) -> <i16 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i16(arg);
+    let result = super::import_primitive_i16_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i32(
+pub fn _import_primitive_i32_add_one(
     env: &RuntimeInstanceData,
     arg: <i32 as WasmAbi>::AbiType,
 ) -> <i32 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i32(arg);
+    let result = super::import_primitive_i32_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i64(
+pub fn _import_primitive_i64_add_one(
     env: &RuntimeInstanceData,
     arg: <i64 as WasmAbi>::AbiType,
 ) -> <i64 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i64(arg);
+    let result = super::import_primitive_i64_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_i8(
+pub fn _import_primitive_i8_add_one(
     env: &RuntimeInstanceData,
     arg: <i8 as WasmAbi>::AbiType,
 ) -> <i8 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_i8(arg);
+    let result = super::import_primitive_i8_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u16(
+pub fn _import_primitive_u16_add_one(
     env: &RuntimeInstanceData,
     arg: <u16 as WasmAbi>::AbiType,
 ) -> <u16 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u16(arg);
+    let result = super::import_primitive_u16_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u32(
+pub fn _import_primitive_u32_add_one(
     env: &RuntimeInstanceData,
     arg: <u32 as WasmAbi>::AbiType,
 ) -> <u32 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u32(arg);
+    let result = super::import_primitive_u32_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u64(
+pub fn _import_primitive_u64_add_one(
     env: &RuntimeInstanceData,
     arg: <u64 as WasmAbi>::AbiType,
 ) -> <u64 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u64(arg);
+    let result = super::import_primitive_u64_add_one(arg);
     result.to_abi()
 }
 
-pub fn _import_primitive_u8(
+pub fn _import_primitive_u8_add_one(
     env: &RuntimeInstanceData,
     arg: <u8 as WasmAbi>::AbiType,
 ) -> <u8 as WasmAbi>::AbiType {
     let arg = WasmAbi::from_abi(arg);
-    let result = super::import_primitive_u8(arg);
+    let result = super::import_primitive_u8_add_one(arg);
     result.to_abi()
 }
 

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -31,17 +31,19 @@ export type Imports = {
     importGetBytes: () => types.Result<Uint8Array, string>;
     importGetSerdeBytes: () => types.Result<ArrayBuffer, string>;
     importMultiplePrimitives: (arg1: number, arg2: string) => bigint;
-    importPrimitiveBool: (arg: boolean) => boolean;
-    importPrimitiveF32: (arg: number) => number;
-    importPrimitiveF64: (arg: number) => number;
-    importPrimitiveI16: (arg: number) => number;
-    importPrimitiveI32: (arg: number) => number;
-    importPrimitiveI64: (arg: bigint) => bigint;
-    importPrimitiveI8: (arg: number) => number;
-    importPrimitiveU16: (arg: number) => number;
-    importPrimitiveU32: (arg: number) => number;
-    importPrimitiveU64: (arg: bigint) => bigint;
-    importPrimitiveU8: (arg: number) => number;
+    importPrimitiveBoolNegate: (arg: boolean) => boolean;
+    importPrimitiveF32AddOne: (arg: number) => number;
+    importPrimitiveF32AddOneWasmer2: (arg: Float32Array) => number;
+    importPrimitiveF64AddOne: (arg: number) => number;
+    importPrimitiveF64AddOneWasmer2: (arg: Float64Array) => number;
+    importPrimitiveI16AddOne: (arg: number) => number;
+    importPrimitiveI32AddOne: (arg: number) => number;
+    importPrimitiveI64AddOne: (arg: bigint) => bigint;
+    importPrimitiveI8AddOne: (arg: number) => number;
+    importPrimitiveU16AddOne: (arg: number) => number;
+    importPrimitiveU32AddOne: (arg: number) => number;
+    importPrimitiveU64AddOne: (arg: bigint) => bigint;
+    importPrimitiveU8AddOne: (arg: number) => number;
     importSerdeAdjacentlyTagged: (arg: types.SerdeAdjacentlyTagged) => types.SerdeAdjacentlyTagged;
     importSerdeEnum: (arg: types.SerdeVariantRenaming) => types.SerdeVariantRenaming;
     importSerdeFlatten: (arg: types.SerdeFlatten) => types.SerdeFlatten;
@@ -78,17 +80,19 @@ export type Exports = {
     exportGetBytes?: () => types.Result<Uint8Array, string>;
     exportGetSerdeBytes?: () => types.Result<ArrayBuffer, string>;
     exportMultiplePrimitives?: (arg1: number, arg2: string) => bigint;
-    exportPrimitiveBool?: (arg: boolean) => boolean;
-    exportPrimitiveF32?: (arg: number) => number;
-    exportPrimitiveF64?: (arg: number) => number;
-    exportPrimitiveI16?: (arg: number) => number;
-    exportPrimitiveI32?: (arg: number) => number;
-    exportPrimitiveI64?: (arg: bigint) => bigint;
-    exportPrimitiveI8?: (arg: number) => number;
-    exportPrimitiveU16?: (arg: number) => number;
-    exportPrimitiveU32?: (arg: number) => number;
-    exportPrimitiveU64?: (arg: bigint) => bigint;
-    exportPrimitiveU8?: (arg: number) => number;
+    exportPrimitiveBoolNegate?: (arg: boolean) => boolean;
+    exportPrimitiveF32AddThree?: (arg: number) => number;
+    exportPrimitiveF32AddThreeWasmer2?: (arg: number) => number;
+    exportPrimitiveF64AddThree?: (arg: number) => number;
+    exportPrimitiveF64AddThreeWasmer2?: (arg: number) => number;
+    exportPrimitiveI16AddThree?: (arg: number) => number;
+    exportPrimitiveI32AddThree?: (arg: number) => number;
+    exportPrimitiveI64AddThree?: (arg: bigint) => bigint;
+    exportPrimitiveI8AddThree?: (arg: number) => number;
+    exportPrimitiveU16AddThree?: (arg: number) => number;
+    exportPrimitiveU32AddThree?: (arg: number) => number;
+    exportPrimitiveU64AddThree?: (arg: bigint) => bigint;
+    exportPrimitiveU8AddThree?: (arg: number) => number;
     exportSerdeAdjacentlyTagged?: (arg: types.SerdeAdjacentlyTagged) => types.SerdeAdjacentlyTagged;
     exportSerdeEnum?: (arg: types.SerdeVariantRenaming) => types.SerdeVariantRenaming;
     exportSerdeFlatten?: (arg: types.SerdeFlatten) => types.SerdeFlatten;
@@ -121,11 +125,11 @@ export type Exports = {
     exportGetBytesRaw?: () => Uint8Array;
     exportGetSerdeBytesRaw?: () => Uint8Array;
     exportMultiplePrimitivesRaw?: (arg1: number, arg2: Uint8Array) => bigint;
-    exportPrimitiveBoolRaw?: (arg: boolean) => boolean;
-    exportPrimitiveI16Raw?: (arg: number) => number;
-    exportPrimitiveI32Raw?: (arg: number) => number;
-    exportPrimitiveI64Raw?: (arg: bigint) => bigint;
-    exportPrimitiveI8Raw?: (arg: number) => number;
+    exportPrimitiveBoolNegateRaw?: (arg: boolean) => boolean;
+    exportPrimitiveI16AddThreeRaw?: (arg: number) => number;
+    exportPrimitiveI32AddThreeRaw?: (arg: number) => number;
+    exportPrimitiveI64AddThreeRaw?: (arg: bigint) => bigint;
+    exportPrimitiveI8AddThreeRaw?: (arg: number) => number;
     exportSerdeAdjacentlyTaggedRaw?: (arg: Uint8Array) => Uint8Array;
     exportSerdeEnumRaw?: (arg: Uint8Array) => Uint8Array;
     exportSerdeFlattenRaw?: (arg: Uint8Array) => Uint8Array;
@@ -328,38 +332,46 @@ export async function createRuntime(
                 const arg2 = parseObject<string>(arg2_ptr);
                 return interpretBigSign(importFunctions.importMultiplePrimitives(arg1, arg2), 9223372036854775808n);
             },
-            __fp_gen_import_primitive_bool: (arg: boolean): boolean => {
-                return !!importFunctions.importPrimitiveBool(arg);
+            __fp_gen_import_primitive_bool_negate: (arg: boolean): boolean => {
+                return !!importFunctions.importPrimitiveBoolNegate(arg);
             },
-            __fp_gen_import_primitive_f32: (arg: number): number => {
-                return importFunctions.importPrimitiveF32(arg);
+            __fp_gen_import_primitive_f32_add_one: (arg: number): number => {
+                return importFunctions.importPrimitiveF32AddOne(arg);
             },
-            __fp_gen_import_primitive_f64: (arg: number): number => {
-                return importFunctions.importPrimitiveF64(arg);
+            __fp_gen_import_primitive_f32_add_one_wasmer2: (arg_ptr: FatPtr): number => {
+                const arg = parseObject<Float32Array>(arg_ptr);
+                return importFunctions.importPrimitiveF32AddOneWasmer2(arg);
             },
-            __fp_gen_import_primitive_i16: (arg: number): number => {
-                return interpretSign(importFunctions.importPrimitiveI16(arg), 32768);
+            __fp_gen_import_primitive_f64_add_one: (arg: number): number => {
+                return importFunctions.importPrimitiveF64AddOne(arg);
             },
-            __fp_gen_import_primitive_i32: (arg: number): number => {
-                return interpretSign(importFunctions.importPrimitiveI32(arg), 2147483648);
+            __fp_gen_import_primitive_f64_add_one_wasmer2: (arg_ptr: FatPtr): number => {
+                const arg = parseObject<Float64Array>(arg_ptr);
+                return importFunctions.importPrimitiveF64AddOneWasmer2(arg);
             },
-            __fp_gen_import_primitive_i64: (arg: bigint): bigint => {
-                return interpretBigSign(importFunctions.importPrimitiveI64(arg), 9223372036854775808n);
+            __fp_gen_import_primitive_i16_add_one: (arg: number): number => {
+                return interpretSign(importFunctions.importPrimitiveI16AddOne(arg), 32768);
             },
-            __fp_gen_import_primitive_i8: (arg: number): number => {
-                return interpretSign(importFunctions.importPrimitiveI8(arg), 128);
+            __fp_gen_import_primitive_i32_add_one: (arg: number): number => {
+                return interpretSign(importFunctions.importPrimitiveI32AddOne(arg), 2147483648);
             },
-            __fp_gen_import_primitive_u16: (arg: number): number => {
-                return importFunctions.importPrimitiveU16(arg);
+            __fp_gen_import_primitive_i64_add_one: (arg: bigint): bigint => {
+                return interpretBigSign(importFunctions.importPrimitiveI64AddOne(arg), 9223372036854775808n);
             },
-            __fp_gen_import_primitive_u32: (arg: number): number => {
-                return importFunctions.importPrimitiveU32(arg);
+            __fp_gen_import_primitive_i8_add_one: (arg: number): number => {
+                return interpretSign(importFunctions.importPrimitiveI8AddOne(arg), 128);
             },
-            __fp_gen_import_primitive_u64: (arg: bigint): bigint => {
-                return importFunctions.importPrimitiveU64(arg);
+            __fp_gen_import_primitive_u16_add_one: (arg: number): number => {
+                return importFunctions.importPrimitiveU16AddOne(arg);
             },
-            __fp_gen_import_primitive_u8: (arg: number): number => {
-                return importFunctions.importPrimitiveU8(arg);
+            __fp_gen_import_primitive_u32_add_one: (arg: number): number => {
+                return importFunctions.importPrimitiveU32AddOne(arg);
+            },
+            __fp_gen_import_primitive_u64_add_one: (arg: bigint): bigint => {
+                return importFunctions.importPrimitiveU64AddOne(arg);
+            },
+            __fp_gen_import_primitive_u8_add_one: (arg: number): number => {
+                return importFunctions.importPrimitiveU8AddOne(arg);
             },
             __fp_gen_import_serde_adjacently_tagged: (arg_ptr: FatPtr): FatPtr => {
                 const arg = parseObject<types.SerdeAdjacentlyTagged>(arg_ptr);
@@ -608,42 +620,44 @@ export async function createRuntime(
                 return interpretBigSign(export_fn(arg1, arg2_ptr), 9223372036854775808n);
             };
         })(),
-        exportPrimitiveBool: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_bool as any;
+        exportPrimitiveBoolNegate: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_bool_negate as any;
             if (!export_fn) return;
 
             return (arg: boolean) => !!export_fn(arg);
         })(),
-        exportPrimitiveF32: instance.exports.__fp_gen_export_primitive_f32 as any,
-        exportPrimitiveF64: instance.exports.__fp_gen_export_primitive_f64 as any,
-        exportPrimitiveI16: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i16 as any;
+        exportPrimitiveF32AddThree: instance.exports.__fp_gen_export_primitive_f32_add_three as any,
+        exportPrimitiveF32AddThreeWasmer2: instance.exports.__fp_gen_export_primitive_f32_add_three_wasmer2 as any,
+        exportPrimitiveF64AddThree: instance.exports.__fp_gen_export_primitive_f64_add_three as any,
+        exportPrimitiveF64AddThreeWasmer2: instance.exports.__fp_gen_export_primitive_f64_add_three_wasmer2 as any,
+        exportPrimitiveI16AddThree: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i16_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 32768);
         })(),
-        exportPrimitiveI32: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i32 as any;
+        exportPrimitiveI32AddThree: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i32_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 2147483648);
         })(),
-        exportPrimitiveI64: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i64 as any;
+        exportPrimitiveI64AddThree: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i64_add_three as any;
             if (!export_fn) return;
 
             return (arg: bigint) => interpretBigSign(export_fn(arg), 9223372036854775808n);
         })(),
-        exportPrimitiveI8: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i8 as any;
+        exportPrimitiveI8AddThree: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i8_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 128);
         })(),
-        exportPrimitiveU16: instance.exports.__fp_gen_export_primitive_u16 as any,
-        exportPrimitiveU32: instance.exports.__fp_gen_export_primitive_u32 as any,
-        exportPrimitiveU64: instance.exports.__fp_gen_export_primitive_u64 as any,
-        exportPrimitiveU8: instance.exports.__fp_gen_export_primitive_u8 as any,
+        exportPrimitiveU16AddThree: instance.exports.__fp_gen_export_primitive_u16_add_three as any,
+        exportPrimitiveU32AddThree: instance.exports.__fp_gen_export_primitive_u32_add_three as any,
+        exportPrimitiveU64AddThree: instance.exports.__fp_gen_export_primitive_u64_add_three as any,
+        exportPrimitiveU8AddThree: instance.exports.__fp_gen_export_primitive_u8_add_three as any,
         exportSerdeAdjacentlyTagged: (() => {
             const export_fn = instance.exports.__fp_gen_export_serde_adjacently_tagged as any;
             if (!export_fn) return;
@@ -910,32 +924,32 @@ export async function createRuntime(
                 return interpretBigSign(export_fn(arg1, arg2_ptr), 9223372036854775808n);
             };
         })(),
-        exportPrimitiveBoolRaw: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_bool as any;
+        exportPrimitiveBoolNegateRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_bool_negate as any;
             if (!export_fn) return;
 
             return (arg: boolean) => !!export_fn(arg);
         })(),
-        exportPrimitiveI16Raw: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i16 as any;
+        exportPrimitiveI16AddThreeRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i16_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 32768);
         })(),
-        exportPrimitiveI32Raw: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i32 as any;
+        exportPrimitiveI32AddThreeRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i32_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 2147483648);
         })(),
-        exportPrimitiveI64Raw: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i64 as any;
+        exportPrimitiveI64AddThreeRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i64_add_three as any;
             if (!export_fn) return;
 
             return (arg: bigint) => interpretBigSign(export_fn(arg), 9223372036854775808n);
         })(),
-        exportPrimitiveI8Raw: (() => {
-            const export_fn = instance.exports.__fp_gen_export_primitive_i8 as any;
+        exportPrimitiveI8AddThreeRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i8_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 128);

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -49,8 +49,11 @@ fp_import! {
 
     // Passing primitives:
     fn import_primitive_bool_negate(arg: bool) -> bool;
-    fn import_primitive_f32_add_one(arg: f32) -> f32;
-    fn import_primitive_f64_add_one(arg: f64) -> f64;
+    // FIXME: Imported functions get 0.0 instead of the float values when called from a plugin.
+    // This is a bug in wasmer 2.3, but can be worked around by using a one-sized array instead.
+    // See https://github.com/fiberplane/fp-bindgen/issues/180
+    fn import_primitive_f32_add_one(arg: [f32; 1]) -> f32;
+    fn import_primitive_f64_add_one(arg: [f64; 1]) -> f64;
     fn import_primitive_i8_add_one(arg: i8) -> i8;
     fn import_primitive_i16_add_one(arg: i16) -> i16;
     fn import_primitive_i32_add_one(arg: i32) -> i32;

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -48,17 +48,17 @@ fp_import! {
     fn import_void_function_empty_result() -> Result<(), u32>;
 
     // Passing primitives:
-    fn import_primitive_bool(arg: bool) -> bool;
-    fn import_primitive_f32(arg: f32) -> f32;
-    fn import_primitive_f64(arg: f64) -> f64;
-    fn import_primitive_i8(arg: i8) -> i8;
-    fn import_primitive_i16(arg: i16) -> i16;
-    fn import_primitive_i32(arg: i32) -> i32;
-    fn import_primitive_i64(arg: i64) -> i64;
-    fn import_primitive_u8(arg: u8) -> u8;
-    fn import_primitive_u16(arg: u16) -> u16;
-    fn import_primitive_u32(arg: u32) -> u32;
-    fn import_primitive_u64(arg: u64) -> u64;
+    fn import_primitive_bool_negate(arg: bool) -> bool;
+    fn import_primitive_f32_add_one(arg: f32) -> f32;
+    fn import_primitive_f64_add_one(arg: f64) -> f64;
+    fn import_primitive_i8_add_one(arg: i8) -> i8;
+    fn import_primitive_i16_add_one(arg: i16) -> i16;
+    fn import_primitive_i32_add_one(arg: i32) -> i32;
+    fn import_primitive_i64_add_one(arg: i64) -> i64;
+    fn import_primitive_u8_add_one(arg: u8) -> u8;
+    fn import_primitive_u16_add_one(arg: u16) -> u16;
+    fn import_primitive_u32_add_one(arg: u32) -> u32;
+    fn import_primitive_u64_add_one(arg: u64) -> u64;
 
     // Passing arrays:
     fn import_array_u8(arg: [u8; 3]) -> [u8; 3];
@@ -137,17 +137,17 @@ fp_export! {
     fn export_void_function();
 
     // Passing primitives:
-    fn export_primitive_bool(arg: bool) -> bool;
-    fn export_primitive_f32(arg: f32) -> f32;
-    fn export_primitive_f64(arg: f64) -> f64;
-    fn export_primitive_i8(arg: i8) -> i8;
-    fn export_primitive_i16(arg: i16) -> i16;
-    fn export_primitive_i32(arg: i32) -> i32;
-    fn export_primitive_i64(arg: i64) -> i64;
-    fn export_primitive_u8(arg: u8) -> u8;
-    fn export_primitive_u16(arg: u16) -> u16;
-    fn export_primitive_u32(arg: u32) -> u32;
-    fn export_primitive_u64(arg: u64) -> u64;
+    fn export_primitive_bool_negate(arg: bool) -> bool;
+    fn export_primitive_f32_add_three(arg: f32) -> f32;
+    fn export_primitive_f64_add_three(arg: f64) -> f64;
+    fn export_primitive_i8_add_three(arg: i8) -> i8;
+    fn export_primitive_i16_add_three(arg: i16) -> i16;
+    fn export_primitive_i32_add_three(arg: i32) -> i32;
+    fn export_primitive_i64_add_three(arg: i64) -> i64;
+    fn export_primitive_u8_add_three(arg: u8) -> u8;
+    fn export_primitive_u16_add_three(arg: u16) -> u16;
+    fn export_primitive_u32_add_three(arg: u32) -> u32;
+    fn export_primitive_u64_add_three(arg: u64) -> u64;
 
     // Passing arrays:
     fn export_array_u8(arg: [u8; 3]) -> [u8; 3];

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -49,11 +49,16 @@ fp_import! {
 
     // Passing primitives:
     fn import_primitive_bool_negate(arg: bool) -> bool;
-    // FIXME: Imported functions get 0.0 instead of the float values when called from a plugin.
-    // This is a bug in wasmer 2.3, but can be worked around by using a one-sized array instead.
+    fn import_primitive_f32_add_one(arg: f32) -> f32;
+    fn import_primitive_f64_add_one(arg: f64) -> f64;
+
+    // NOTICE: This is a workaround for a bug in wasmer 2.3, where imported functions
+    // receive 0.0 instead of the the float value they were called with.
+    // This bug is fixed in wasmer 3, but in the meantime, you can use this workaround.
     // See https://github.com/fiberplane/fp-bindgen/issues/180
-    fn import_primitive_f32_add_one(arg: [f32; 1]) -> f32;
-    fn import_primitive_f64_add_one(arg: [f64; 1]) -> f64;
+    fn import_primitive_f32_add_one_wasmer2(arg: [f32; 1]) -> f32;
+    fn import_primitive_f64_add_one_wasmer2(arg: [f64; 1]) -> f64;
+
     fn import_primitive_i8_add_one(arg: i8) -> i8;
     fn import_primitive_i16_add_one(arg: i16) -> i16;
     fn import_primitive_i32_add_one(arg: i32) -> i32;
@@ -143,6 +148,8 @@ fp_export! {
     fn export_primitive_bool_negate(arg: bool) -> bool;
     fn export_primitive_f32_add_three(arg: f32) -> f32;
     fn export_primitive_f64_add_three(arg: f64) -> f64;
+    fn export_primitive_f32_add_three_wasmer2(arg: f32) -> f32;
+    fn export_primitive_f64_add_three_wasmer2(arg: f64) -> f64;
     fn export_primitive_i8_add_three(arg: i8) -> i8;
     fn export_primitive_i16_add_three(arg: i16) -> i16;
     fn export_primitive_i32_add_three(arg: i32) -> i32;

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -17,11 +17,11 @@ fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>) {
 fn import_primitive_bool_negate(arg: bool) -> bool {
     !arg
 }
-fn import_primitive_f32_add_one(arg: f32) -> f32 {
-    arg + 1.0
+fn import_primitive_f32_add_one(arg: [f32; 1]) -> f32 {
+    arg[0] + 1.0
 }
-fn import_primitive_f64_add_one(arg: f64) -> f64 {
-    arg + 1.0
+fn import_primitive_f64_add_one(arg: [f64; 1]) -> f64 {
+    arg[0] + 1.0
 }
 fn import_primitive_i8_add_one(arg: i8) -> i8 {
     arg + 1

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -14,38 +14,38 @@ fn import_void_function_empty_return() -> () {}
 fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>) {
     todo!()
 }
-fn import_primitive_bool(arg: bool) -> bool {
-    todo!()
+fn import_primitive_bool_negate(arg: bool) -> bool {
+    !arg
 }
-fn import_primitive_f32(arg: f32) -> f32 {
-    todo!()
+fn import_primitive_f32_add_one(arg: f32) -> f32 {
+    arg + 1.0
 }
-fn import_primitive_f64(arg: f64) -> f64 {
-    todo!()
+fn import_primitive_f64_add_one(arg: f64) -> f64 {
+    arg + 1.0
 }
-fn import_primitive_i8(arg: i8) -> i8 {
-    todo!()
+fn import_primitive_i8_add_one(arg: i8) -> i8 {
+    arg + 1
 }
-fn import_primitive_i16(arg: i16) -> i16 {
-    todo!()
+fn import_primitive_i16_add_one(arg: i16) -> i16 {
+    arg + 1
 }
-fn import_primitive_i32(arg: i32) -> i32 {
-    todo!()
+fn import_primitive_i32_add_one(arg: i32) -> i32 {
+    arg + 1
 }
-fn import_primitive_i64(arg: i64) -> i64 {
-    todo!()
+fn import_primitive_i64_add_one(arg: i64) -> i64 {
+    arg + 1
 }
-fn import_primitive_u8(arg: u8) -> u8 {
-    todo!()
+fn import_primitive_u8_add_one(arg: u8) -> u8 {
+    arg + 1
 }
-fn import_primitive_u16(arg: u16) -> u16 {
-    todo!()
+fn import_primitive_u16_add_one(arg: u16) -> u16 {
+    arg + 1
 }
-fn import_primitive_u32(arg: u32) -> u32 {
-    todo!()
+fn import_primitive_u32_add_one(arg: u32) -> u32 {
+    arg + 1
 }
-fn import_primitive_u64(arg: u64) -> u64 {
-    todo!()
+fn import_primitive_u64_add_one(arg: u64) -> u64 {
+    arg + 1
 }
 
 fn import_array_u8(arg: [u8; 3]) -> [u8; 3] {

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -17,10 +17,16 @@ fn import_explicit_bound_point(arg: ExplicitBoundPoint<u64>) {
 fn import_primitive_bool_negate(arg: bool) -> bool {
     !arg
 }
-fn import_primitive_f32_add_one(arg: [f32; 1]) -> f32 {
+fn import_primitive_f32_add_one(arg: f32) -> f32 {
+    arg + 1.0
+}
+fn import_primitive_f64_add_one(arg: f64) -> f64 {
+    arg + 1.0
+}
+fn import_primitive_f32_add_one_wasmer2(arg: [f32; 1]) -> f32 {
     arg[0] + 1.0
 }
-fn import_primitive_f64_add_one(arg: [f64; 1]) -> f64 {
+fn import_primitive_f64_add_one_wasmer2(arg: [f64; 1]) -> f64 {
     arg[0] + 1.0
 }
 fn import_primitive_i8_add_one(arg: i8) -> i8 {

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -151,7 +151,7 @@ fn log(msg: String) {
 
 async fn make_http_request(opts: Request) -> Result<Response, RequestError> {
     Ok(Response {
-        body: ByteBuf::from(r#"status: "confirmed"#.to_string()),
+        body: ByteBuf::from(r#"status: "confirmed""#.to_string()),
         headers: opts.headers,
         status_code: 200,
     })

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -23,27 +23,27 @@ const WASM_BYTES: &'static [u8] =
 fn primitives() -> Result<()> {
     let rt = new_runtime()?;
 
-    assert_eq!(rt.export_primitive_bool(true)?, true);
-    assert_eq!(rt.export_primitive_bool(false)?, false);
+    assert_eq!(rt.export_primitive_bool_negate(true)?, false);
+    assert_eq!(rt.export_primitive_bool_negate(false)?, true);
 
-    assert_eq!(rt.export_primitive_u8(8)?, 8);
-    assert_eq!(rt.export_primitive_u16(16)?, 16);
-    assert_eq!(rt.export_primitive_u32(32)?, 32);
-    assert_eq!(rt.export_primitive_u64(64)?, 64);
-    assert_eq!(rt.export_primitive_i8(-8)?, -8);
-    assert_eq!(rt.export_primitive_i16(-16)?, -16);
-    assert_eq!(rt.export_primitive_i32(-32)?, -32);
-    assert_eq!(rt.export_primitive_i64(-64)?, -64);
+    assert_eq!(rt.export_primitive_u8_add_three(8)?, 8 + 3);
+    assert_eq!(rt.export_primitive_u16_add_three(16)?, 16 + 3);
+    assert_eq!(rt.export_primitive_u32_add_three(32)?, 32 + 3);
+    assert_eq!(rt.export_primitive_u64_add_three(64)?, 64 + 3);
+    assert_eq!(rt.export_primitive_i8_add_three(-8)?, -8 + 3);
+    assert_eq!(rt.export_primitive_i16_add_three(-16)?, -16 + 3);
+    assert_eq!(rt.export_primitive_i32_add_three(-32)?, -32 + 3);
+    assert_eq!(rt.export_primitive_i64_add_three(-64)?, -64 + 3);
 
     assert_eq!(
         rt.export_multiple_primitives(-8, "Hello, 🇳🇱!".to_string())?,
         -64
     );
 
-    assert_eq!(rt.export_primitive_f32(3.1415926535)?, 3.1415926535);
+    assert_eq!(rt.export_primitive_f32_add_three(3.5)?, 3.5 + 3.0);
     assert_eq!(
-        rt.export_primitive_f64(2.718281828459f64)?,
-        2.718281828459f64
+        rt.export_primitive_f64_add_three(2.5)?,
+        2.5 + 3.0
     );
     Ok(())
 }

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -268,7 +268,7 @@ async fn fetch_async_data() -> Result<()> {
 
     let response = rt.fetch_data("sign-up".to_string()).await?;
 
-    assert_eq!(response, Ok(r#"status: "confirmed"#.to_string()));
+    assert_eq!(response, Ok(r#"status: "confirmed""#.to_string()));
     Ok(())
 }
 

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -48,11 +48,9 @@ fn primitives() -> Result<()> {
     //     2.5 + 3.0
     // );
 
+    // Precise float comparison is fine as long as the denominator is a power of two
     assert_eq!(rt.export_primitive_f32_add_three_wasmer2(3.5)?, 3.5 + 3.0);
-    assert_eq!(
-        rt.export_primitive_f64_add_three_wasmer2(2.5)?,
-        2.5 + 3.0
-    );
+    assert_eq!(rt.export_primitive_f64_add_three_wasmer2(2.5)?, 2.5 + 3.0);
 
     Ok(())
 }

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -40,11 +40,20 @@ fn primitives() -> Result<()> {
         -64
     );
 
-    assert_eq!(rt.export_primitive_f32_add_three(3.5)?, 3.5 + 3.0);
+    // FIXME: because of a bug in wasmer 2, we must use a workaround to pass float values to host.
+    // Uncomment these tests in the wasmer3 branch, since the bug is fixed there.
+    // assert_eq!(rt.export_primitive_f32_add_three(3.5)?, 3.5 + 3.0);
+    // assert_eq!(
+    //     rt.export_primitive_f64_add_three(2.5)?,
+    //     2.5 + 3.0
+    // );
+
+    assert_eq!(rt.export_primitive_f32_add_three_wasmer2(3.5)?, 3.5 + 3.0);
     assert_eq!(
-        rt.export_primitive_f64_add_three(2.5)?,
+        rt.export_primitive_f64_add_three_wasmer2(2.5)?,
         2.5 + 3.0
     );
+
     Ok(())
 }
 


### PR DESCRIPTION
Adding tests that go back and forth makes the testing more robust, as it tests the interaction of a larger part of the system.

Addresses #180, but there is still more to do, for example generating a warning when an imported function takes `f32`/`f64`, or marking it as deprecated with a link to this issue.