### PR TITLE
Fix async functions that return a primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added workaround for imported functions with float arguments for wasmer2 in example,
   see [#180](https://github.com/fiberplane/fp-bindgen/issues/180).
+- Fixed async functions returning primitive values, including void async functions,
+  see [#178](https://github.com/fiberplane/fp-bindgen/issues/178).
 
 ## [3.0.0-beta.1] - 2023-02-14
 

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -30,6 +30,7 @@ import { Result } from "../example-protocol/bindings/ts-runtime/types.ts";
 import { loadPlugin } from "./loader.ts";
 
 let voidFunctionCalled = false;
+let globalState = 0;
 
 const imports: Imports = {
   importExplicitBoundPoint: (arg: ExplicitBoundPoint<number>) => {
@@ -310,6 +311,16 @@ const imports: Imports = {
     return Promise.resolve(Number(arg) + 1);
   },
 
+  importIncrementGlobalState: (): Promise<void> => {
+    globalState = globalState + 1;
+    return Promise.resolve();
+  },
+
+  importResetGlobalState: (): Promise<void> => {
+    globalState = 0;
+    return Promise.resolve();
+  },
+
   log: (message: string): void => {
     console.log("Plugin log: " + message);
   },
@@ -565,6 +576,15 @@ Deno.test("async primitives", async () => {
   assertEquals(await plugin.exportPrimitiveI16AddThreeAsync?.(-16), -16 + 3);
   assertEquals(await plugin.exportPrimitiveI32AddThreeAsync?.(-32), -32 + 3);
   assertEquals(await plugin.exportPrimitiveI64AddThreeAsync?.(-64n), -64 + 3);
+
+  await plugin.exportResetGlobalState?.();
+  await plugin.exportIncrementGlobalState?.();
+  assertEquals(globalState, 1);
+
+  await plugin.exportResetGlobalState?.();
+  await plugin.exportIncrementGlobalState?.();
+  await plugin.exportIncrementGlobalState?.();
+  assertEquals(globalState, 2);
 });
 
 Deno.test("async struct", async () => {

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -547,6 +547,26 @@ Deno.test("tagged enums", async () => {
   });
 });
 
+Deno.test("async primitives", async () => {
+  const plugin = await loadExamplePlugin();
+
+  assertEquals(await plugin.exportPrimitiveBoolNegateAsync?.(true), false);
+  assertEquals(await plugin.exportPrimitiveBoolNegateAsync?.(false), true);
+
+  // Precise float comparison is fine as long as the denominator is a power of two
+  assertEquals(await plugin.exportPrimitiveF32AddThreeAsync?.(3.5), 3.5 + 3.0);
+  assertEquals(await plugin.exportPrimitiveF64AddThreeAsync?.(2.5), 2.5 + 3.0);
+
+  assertEquals(await plugin.exportPrimitiveU8AddThreeAsync?.(8), 8 + 3);
+  assertEquals(await plugin.exportPrimitiveU16AddThreeAsync?.(16), 16 + 3);
+  assertEquals(await plugin.exportPrimitiveU32AddThreeAsync?.(32), 32 + 3);
+  assertEquals(await plugin.exportPrimitiveU64AddThreeAsync?.(64n), 64 + 3);
+  assertEquals(await plugin.exportPrimitiveI8AddThreeAsync?.(-8), -8 + 3);
+  assertEquals(await plugin.exportPrimitiveI16AddThreeAsync?.(-16), -16 + 3);
+  assertEquals(await plugin.exportPrimitiveI32AddThreeAsync?.(-32), -32 + 3);
+  assertEquals(await plugin.exportPrimitiveI64AddThreeAsync?.(-64n), -64 + 3);
+});
+
 Deno.test("async struct", async () => {
   const { exportAsyncStruct } = await loadExamplePlugin();
   assert(exportAsyncStruct);

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -263,6 +263,53 @@ const imports: Imports = {
 
   importVoidFunctionEmptyReturn: (): void => {},
 
+  importPrimitiveBoolNegateAsync: (arg: boolean): Promise<boolean> => {
+    return Promise.resolve(!arg);
+  },
+
+  importPrimitiveF32AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveF64AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveI8AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveI16AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveI32AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  // Message pack doesn't support bigint yet, so 64-bit numbers are
+  // represented as `number` in complex structs, including promises.
+  // See https://github.com/msgpack/msgpack-javascript/pull/211
+  importPrimitiveI64AddOneAsync: (arg: bigint): Promise<number> => {
+    return Promise.resolve(Number(arg) + 1);
+  },
+
+  importPrimitiveU8AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveU16AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveU32AddOneAsync: (arg: number): Promise<number> => {
+    return Promise.resolve(arg + 1);
+  },
+
+  importPrimitiveU64AddOneAsync: (arg: bigint): Promise<number> => {
+    return Promise.resolve(Number(arg) + 1);
+  },
+
   log: (message: string): void => {
     console.log("Plugin log: " + message);
   },

--- a/examples/example-deno-runtime/tests.ts
+++ b/examples/example-deno-runtime/tests.ts
@@ -384,7 +384,7 @@ Deno.test("primitives", async () => {
   assertEquals(plugin.exportPrimitiveF32AddThree?.(3.5), 3.5 + 3.0);
   assertEquals(plugin.exportPrimitiveF64AddThree?.(2.5), 2.5 + 3.0);
 
-  // We need to define the workarounf methods for wasmer2, so we might as well test them
+  // We need to define the workaround methods for wasmer2, so we might as well test them
   assertEquals(plugin.exportPrimitiveF32AddThreeWasmer2?.(13.5), 13.5 + 3.0);
   assertEquals(plugin.exportPrimitiveF64AddThreeWasmer2?.(12.5), 12.5 + 3.0);
 });

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -373,6 +373,16 @@ async fn export_primitive_u64_add_three_async(arg: u64) -> u64 {
 }
 
 #[fp_export_impl(example_bindings)]
+async fn export_reset_global_state() {
+    import_reset_global_state().await
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_increment_global_state() {
+    import_increment_global_state().await
+}
+
+#[fp_export_impl(example_bindings)]
 async fn export_async_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming {
     assert_eq!(
         arg1,

--- a/examples/example-plugin/src/lib.rs
+++ b/examples/example-plugin/src/lib.rs
@@ -318,6 +318,61 @@ fn export_serde_untagged(arg: SerdeUntagged) -> SerdeUntagged {
 }
 
 #[fp_export_impl(example_bindings)]
+async fn export_primitive_bool_negate_async(arg: bool) -> bool {
+    !import_primitive_bool_negate_async(!arg).await
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_f32_add_three_async(arg: f32) -> f32 {
+    import_primitive_f32_add_one_async(arg + 1.0).await + 1.0
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_f64_add_three_async(arg: f64) -> f64 {
+    import_primitive_f64_add_one_async(arg + 1.0).await + 1.0
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_i8_add_three_async(arg: i8) -> i8 {
+    import_primitive_i8_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_i16_add_three_async(arg: i16) -> i16 {
+    import_primitive_i16_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_i32_add_three_async(arg: i32) -> i32 {
+    import_primitive_i32_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_i64_add_three_async(arg: i64) -> i64 {
+    import_primitive_i64_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_u8_add_three_async(arg: u8) -> u8 {
+    import_primitive_u8_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_u16_add_three_async(arg: u16) -> u16 {
+    import_primitive_u16_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_u32_add_three_async(arg: u32) -> u32 {
+    import_primitive_u32_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
+async fn export_primitive_u64_add_three_async(arg: u64) -> u64 {
+    import_primitive_u64_add_one_async(arg + 1).await + 1
+}
+
+#[fp_export_impl(example_bindings)]
 async fn export_async_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming {
     assert_eq!(
         arg1,

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_export.rs
@@ -55,13 +55,22 @@ pub fn export_get_bytes() -> Result<bytes::Bytes, String>;
 pub fn export_get_serde_bytes() -> Result<serde_bytes::ByteBuf, String>;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_increment_global_state();
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_multiple_primitives(arg1: i8, arg2: String) -> i64;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_bool_negate(arg: bool) -> bool;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_bool_negate_async(arg: bool) -> bool;
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_f32_add_three(arg: f32) -> f32;
+
+#[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_f32_add_three_async(arg: f32) -> f32;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_f32_add_three_wasmer2(arg: f32) -> f32;
@@ -70,31 +79,61 @@ pub fn export_primitive_f32_add_three_wasmer2(arg: f32) -> f32;
 pub fn export_primitive_f64_add_three(arg: f64) -> f64;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_f64_add_three_async(arg: f64) -> f64;
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_f64_add_three_wasmer2(arg: f64) -> f64;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_i16_add_three(arg: i16) -> i16;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_i16_add_three_async(arg: i16) -> i16;
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_i32_add_three(arg: i32) -> i32;
+
+#[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_i32_add_three_async(arg: i32) -> i32;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_i64_add_three(arg: i64) -> i64;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_i64_add_three_async(arg: i64) -> i64;
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_i8_add_three(arg: i8) -> i8;
+
+#[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_i8_add_three_async(arg: i8) -> i8;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_u16_add_three(arg: u16) -> u16;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_u16_add_three_async(arg: u16) -> u16;
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_u32_add_three(arg: u32) -> u32;
+
+#[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_u32_add_three_async(arg: u32) -> u32;
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_u64_add_three(arg: u64) -> u64;
 
 #[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_u64_add_three_async(arg: u64) -> u64;
+
+#[fp_bindgen_support::fp_export_signature]
 pub fn export_primitive_u8_add_three(arg: u8) -> u8;
+
+#[fp_bindgen_support::fp_export_signature]
+pub async fn export_primitive_u8_add_three_async(arg: u8) -> u8;
+
+#[fp_bindgen_support::fp_export_signature]
+pub async fn export_reset_global_state();
 
 #[fp_bindgen_support::fp_export_signature]
 pub fn export_serde_adjacently_tagged(arg: SerdeAdjacentlyTagged) -> SerdeAdjacentlyTagged;

--- a/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
+++ b/examples/example-protocol/src/assets/rust_plugin_test/expected_import.rs
@@ -55,13 +55,22 @@ pub fn import_get_bytes() -> Result<bytes::Bytes, String>;
 pub fn import_get_serde_bytes() -> Result<serde_bytes::ByteBuf, String>;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_increment_global_state();
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_multiple_primitives(arg1: i8, arg2: String) -> i64;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_bool_negate(arg: bool) -> bool;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_bool_negate_async(arg: bool) -> bool;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_f32_add_one(arg: f32) -> f32;
+
+#[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_f32_add_one_async(arg: f32) -> f32;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_f32_add_one_wasmer2(arg: [f32; 1]) -> f32;
@@ -70,31 +79,61 @@ pub fn import_primitive_f32_add_one_wasmer2(arg: [f32; 1]) -> f32;
 pub fn import_primitive_f64_add_one(arg: f64) -> f64;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_f64_add_one_async(arg: f64) -> f64;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_f64_add_one_wasmer2(arg: [f64; 1]) -> f64;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_i16_add_one(arg: i16) -> i16;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_i16_add_one_async(arg: i16) -> i16;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_i32_add_one(arg: i32) -> i32;
+
+#[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_i32_add_one_async(arg: i32) -> i32;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_i64_add_one(arg: i64) -> i64;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_i64_add_one_async(arg: i64) -> i64;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_i8_add_one(arg: i8) -> i8;
+
+#[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_i8_add_one_async(arg: i8) -> i8;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_u16_add_one(arg: u16) -> u16;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_u16_add_one_async(arg: u16) -> u16;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_u32_add_one(arg: u32) -> u32;
+
+#[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_u32_add_one_async(arg: u32) -> u32;
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_u64_add_one(arg: u64) -> u64;
 
 #[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_u64_add_one_async(arg: u64) -> u64;
+
+#[fp_bindgen_support::fp_import_signature]
 pub fn import_primitive_u8_add_one(arg: u8) -> u8;
+
+#[fp_bindgen_support::fp_import_signature]
+pub async fn import_primitive_u8_add_one_async(arg: u8) -> u8;
+
+#[fp_bindgen_support::fp_import_signature]
+pub async fn import_reset_global_state();
 
 #[fp_bindgen_support::fp_import_signature]
 pub fn import_serde_adjacently_tagged(arg: SerdeAdjacentlyTagged) -> SerdeAdjacentlyTagged;

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -439,6 +439,27 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_increment_global_state(&self) -> Result<(), InvocationError> {
+        let result = self.export_increment_global_state_raw();
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_increment_global_state_raw(&self) -> Result<(), InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<(), ()>("__fp_gen_export_increment_global_state")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_increment_global_state".to_owned(),
+                )
+            })?;
+        let result = function.call()?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_multiple_primitives(
         &self,
         arg1: i8,
@@ -491,6 +512,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_bool_negate_async(
+        &self,
+        arg: bool,
+    ) -> Result<bool, InvocationError> {
+        let result = self.export_primitive_bool_negate_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_bool_negate_async_raw(
+        &self,
+        arg: bool,
+    ) -> Result<bool, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_bool_negate_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_bool_negate_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_f32_add_three(&self, arg: f32) -> Result<f32, InvocationError> {
         let result = self.export_primitive_f32_add_three_raw(arg);
         result
@@ -509,6 +559,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_f32_add_three_async(
+        &self,
+        arg: f32,
+    ) -> Result<f32, InvocationError> {
+        let result = self.export_primitive_f32_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_f32_add_three_async_raw(
+        &self,
+        arg: f32,
+    ) -> Result<f32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f32_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f32_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -557,6 +636,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_f64_add_three_async(
+        &self,
+        arg: f64,
+    ) -> Result<f64, InvocationError> {
+        let result = self.export_primitive_f64_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_f64_add_three_async_raw(
+        &self,
+        arg: f64,
+    ) -> Result<f64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f64_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f64_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_f64_add_three_wasmer2(&self, arg: f64) -> Result<f64, InvocationError> {
         let result = self.export_primitive_f64_add_three_wasmer2_raw(arg);
         result
@@ -602,6 +710,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_i16_add_three_async(
+        &self,
+        arg: i16,
+    ) -> Result<i16, InvocationError> {
+        let result = self.export_primitive_i16_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i16_add_three_async_raw(
+        &self,
+        arg: i16,
+    ) -> Result<i16, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i16_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i16_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_i32_add_three(&self, arg: i32) -> Result<i32, InvocationError> {
         let result = self.export_primitive_i32_add_three_raw(arg);
         result
@@ -620,6 +757,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_i32_add_three_async(
+        &self,
+        arg: i32,
+    ) -> Result<i32, InvocationError> {
+        let result = self.export_primitive_i32_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i32_add_three_async_raw(
+        &self,
+        arg: i32,
+    ) -> Result<i32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i32_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i32_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -644,6 +810,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_i64_add_three_async(
+        &self,
+        arg: i64,
+    ) -> Result<i64, InvocationError> {
+        let result = self.export_primitive_i64_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i64_add_three_async_raw(
+        &self,
+        arg: i64,
+    ) -> Result<i64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i64_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i64_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_i8_add_three(&self, arg: i8) -> Result<i8, InvocationError> {
         let result = self.export_primitive_i8_add_three_raw(arg);
         result
@@ -662,6 +857,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_i8_add_three_async(
+        &self,
+        arg: i8,
+    ) -> Result<i8, InvocationError> {
+        let result = self.export_primitive_i8_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i8_add_three_async_raw(
+        &self,
+        arg: i8,
+    ) -> Result<i8, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i8_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i8_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -686,6 +910,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_u16_add_three_async(
+        &self,
+        arg: u16,
+    ) -> Result<u16, InvocationError> {
+        let result = self.export_primitive_u16_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u16_add_three_async_raw(
+        &self,
+        arg: u16,
+    ) -> Result<u16, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u16_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u16_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_u32_add_three(&self, arg: u32) -> Result<u32, InvocationError> {
         let result = self.export_primitive_u32_add_three_raw(arg);
         result
@@ -704,6 +957,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_u32_add_three_async(
+        &self,
+        arg: u32,
+    ) -> Result<u32, InvocationError> {
+        let result = self.export_primitive_u32_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u32_add_three_async_raw(
+        &self,
+        arg: u32,
+    ) -> Result<u32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u32_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u32_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -728,6 +1010,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_u64_add_three_async(
+        &self,
+        arg: u64,
+    ) -> Result<u64, InvocationError> {
+        let result = self.export_primitive_u64_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u64_add_three_async_raw(
+        &self,
+        arg: u64,
+    ) -> Result<u64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u64_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u64_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_u8_add_three(&self, arg: u8) -> Result<u8, InvocationError> {
         let result = self.export_primitive_u8_add_three_raw(arg);
         result
@@ -746,6 +1057,56 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_u8_add_three_async(
+        &self,
+        arg: u8,
+    ) -> Result<u8, InvocationError> {
+        let result = self.export_primitive_u8_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u8_add_three_async_raw(
+        &self,
+        arg: u8,
+    ) -> Result<u8, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u8_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u8_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
+    pub async fn export_reset_global_state(&self) -> Result<(), InvocationError> {
+        let result = self.export_reset_global_state_raw();
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_reset_global_state_raw(&self) -> Result<(), InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<(), ()>("__fp_gen_export_reset_global_state")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_reset_global_state".to_owned(),
+                )
+            })?;
+        let result = function.call()?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -1059,20 +1420,33 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> ImportObjec
             "__fp_gen_import_generics" => Function::new_native_with_env(store, env.clone(), _import_generics),
             "__fp_gen_import_get_bytes" => Function::new_native_with_env(store, env.clone(), _import_get_bytes),
             "__fp_gen_import_get_serde_bytes" => Function::new_native_with_env(store, env.clone(), _import_get_serde_bytes),
+            "__fp_gen_import_increment_global_state" => Function::new_native_with_env(store, env.clone(), _import_increment_global_state),
             "__fp_gen_import_multiple_primitives" => Function::new_native_with_env(store, env.clone(), _import_multiple_primitives),
             "__fp_gen_import_primitive_bool_negate" => Function::new_native_with_env(store, env.clone(), _import_primitive_bool_negate),
+            "__fp_gen_import_primitive_bool_negate_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_bool_negate_async),
             "__fp_gen_import_primitive_f32_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one),
+            "__fp_gen_import_primitive_f32_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one_async),
             "__fp_gen_import_primitive_f32_add_one_wasmer2" => Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one_wasmer2),
             "__fp_gen_import_primitive_f64_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one),
+            "__fp_gen_import_primitive_f64_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one_async),
             "__fp_gen_import_primitive_f64_add_one_wasmer2" => Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one_wasmer2),
             "__fp_gen_import_primitive_i16_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i16_add_one),
+            "__fp_gen_import_primitive_i16_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_i16_add_one_async),
             "__fp_gen_import_primitive_i32_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i32_add_one),
+            "__fp_gen_import_primitive_i32_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_i32_add_one_async),
             "__fp_gen_import_primitive_i64_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i64_add_one),
+            "__fp_gen_import_primitive_i64_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_i64_add_one_async),
             "__fp_gen_import_primitive_i8_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_i8_add_one),
+            "__fp_gen_import_primitive_i8_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_i8_add_one_async),
             "__fp_gen_import_primitive_u16_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u16_add_one),
+            "__fp_gen_import_primitive_u16_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_u16_add_one_async),
             "__fp_gen_import_primitive_u32_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u32_add_one),
+            "__fp_gen_import_primitive_u32_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_u32_add_one_async),
             "__fp_gen_import_primitive_u64_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u64_add_one),
+            "__fp_gen_import_primitive_u64_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_u64_add_one_async),
             "__fp_gen_import_primitive_u8_add_one" => Function::new_native_with_env(store, env.clone(), _import_primitive_u8_add_one),
+            "__fp_gen_import_primitive_u8_add_one_async" => Function::new_native_with_env(store, env.clone(), _import_primitive_u8_add_one_async),
+            "__fp_gen_import_reset_global_state" => Function::new_native_with_env(store, env.clone(), _import_reset_global_state),
             "__fp_gen_import_serde_adjacently_tagged" => Function::new_native_with_env(store, env.clone(), _import_serde_adjacently_tagged),
             "__fp_gen_import_serde_enum" => Function::new_native_with_env(store, env.clone(), _import_serde_enum),
             "__fp_gen_import_serde_flatten" => Function::new_native_with_env(store, env.clone(), _import_serde_flatten),
@@ -1196,6 +1570,19 @@ pub fn _import_get_serde_bytes(env: &RuntimeInstanceData) -> FatPtr {
     export_to_guest(env, &result)
 }
 
+pub fn _import_increment_global_state(env: &RuntimeInstanceData) -> FatPtr {
+    let result = super::import_increment_global_state();
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_multiple_primitives(
     env: &RuntimeInstanceData,
     arg1: <i8 as WasmAbi>::AbiType,
@@ -1216,6 +1603,23 @@ pub fn _import_primitive_bool_negate(
     result.to_abi()
 }
 
+pub fn _import_primitive_bool_negate_async(
+    env: &RuntimeInstanceData,
+    arg: <bool as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_bool_negate_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_f32_add_one(
     env: &RuntimeInstanceData,
     arg: <f32 as WasmAbi>::AbiType,
@@ -1223,6 +1627,23 @@ pub fn _import_primitive_f32_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_f32_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_f32_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <f32 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_f32_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_f32_add_one_wasmer2(
@@ -1243,6 +1664,23 @@ pub fn _import_primitive_f64_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_f64_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <f64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_f64_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_f64_add_one_wasmer2(
     env: &RuntimeInstanceData,
     arg: FatPtr,
@@ -1261,6 +1699,23 @@ pub fn _import_primitive_i16_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_i16_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i16 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i16_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_i32_add_one(
     env: &RuntimeInstanceData,
     arg: <i32 as WasmAbi>::AbiType,
@@ -1268,6 +1723,23 @@ pub fn _import_primitive_i32_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_i32_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_i32_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i32 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i32_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_i64_add_one(
@@ -1279,6 +1751,23 @@ pub fn _import_primitive_i64_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_i64_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i64_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_i8_add_one(
     env: &RuntimeInstanceData,
     arg: <i8 as WasmAbi>::AbiType,
@@ -1286,6 +1775,23 @@ pub fn _import_primitive_i8_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_i8_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_i8_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i8 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i8_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_u16_add_one(
@@ -1297,6 +1803,23 @@ pub fn _import_primitive_u16_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_u16_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u16 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u16_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_u32_add_one(
     env: &RuntimeInstanceData,
     arg: <u32 as WasmAbi>::AbiType,
@@ -1304,6 +1827,23 @@ pub fn _import_primitive_u32_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_u32_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_u32_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u32 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u32_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_u64_add_one(
@@ -1315,6 +1855,23 @@ pub fn _import_primitive_u64_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_u64_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u64_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_u8_add_one(
     env: &RuntimeInstanceData,
     arg: <u8 as WasmAbi>::AbiType,
@@ -1322,6 +1879,36 @@ pub fn _import_primitive_u8_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_u8_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_u8_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u8 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u8_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
+pub fn _import_reset_global_state(env: &RuntimeInstanceData) -> FatPtr {
+    let result = super::import_reset_global_state();
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_serde_adjacently_tagged(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {

--- a/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_runtime_test/expected_bindings.rs
@@ -445,11 +445,11 @@ impl Runtime {
         let result = result.map(|ref data| deserialize_from_slice(data));
         result
     }
-    pub async fn export_increment_global_state_raw(&self) -> Result<(), InvocationError> {
+    pub async fn export_increment_global_state_raw(&self) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<(), ()>("__fp_gen_export_increment_global_state")
+            .get_native_function::<(), FatPtr>("__fp_gen_export_increment_global_state")
             .map_err(|_| {
                 InvocationError::FunctionNotExported(
                     "__fp_gen_export_increment_global_state".to_owned(),
@@ -524,11 +524,11 @@ impl Runtime {
     pub async fn export_primitive_bool_negate_async_raw(
         &self,
         arg: bool,
-    ) -> Result<bool, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
+            .get_native_function::<<bool as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_bool_negate_async",
             )
             .map_err(|_| {
@@ -574,11 +574,11 @@ impl Runtime {
     pub async fn export_primitive_f32_add_three_async_raw(
         &self,
         arg: f32,
-    ) -> Result<f32, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
+            .get_native_function::<<f32 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_f32_add_three_async",
             )
             .map_err(|_| {
@@ -648,11 +648,11 @@ impl Runtime {
     pub async fn export_primitive_f64_add_three_async_raw(
         &self,
         arg: f64,
-    ) -> Result<f64, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
+            .get_native_function::<<f64 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_f64_add_three_async",
             )
             .map_err(|_| {
@@ -722,11 +722,11 @@ impl Runtime {
     pub async fn export_primitive_i16_add_three_async_raw(
         &self,
         arg: i16,
-    ) -> Result<i16, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
+            .get_native_function::<<i16 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i16_add_three_async",
             )
             .map_err(|_| {
@@ -772,11 +772,11 @@ impl Runtime {
     pub async fn export_primitive_i32_add_three_async_raw(
         &self,
         arg: i32,
-    ) -> Result<i32, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
+            .get_native_function::<<i32 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i32_add_three_async",
             )
             .map_err(|_| {
@@ -822,11 +822,11 @@ impl Runtime {
     pub async fn export_primitive_i64_add_three_async_raw(
         &self,
         arg: i64,
-    ) -> Result<i64, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
+            .get_native_function::<<i64 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i64_add_three_async",
             )
             .map_err(|_| {
@@ -872,11 +872,11 @@ impl Runtime {
     pub async fn export_primitive_i8_add_three_async_raw(
         &self,
         arg: i8,
-    ) -> Result<i8, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
+            .get_native_function::<<i8 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i8_add_three_async",
             )
             .map_err(|_| {
@@ -922,11 +922,11 @@ impl Runtime {
     pub async fn export_primitive_u16_add_three_async_raw(
         &self,
         arg: u16,
-    ) -> Result<u16, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
+            .get_native_function::<<u16 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u16_add_three_async",
             )
             .map_err(|_| {
@@ -972,11 +972,11 @@ impl Runtime {
     pub async fn export_primitive_u32_add_three_async_raw(
         &self,
         arg: u32,
-    ) -> Result<u32, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
+            .get_native_function::<<u32 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u32_add_three_async",
             )
             .map_err(|_| {
@@ -1022,11 +1022,11 @@ impl Runtime {
     pub async fn export_primitive_u64_add_three_async_raw(
         &self,
         arg: u64,
-    ) -> Result<u64, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
+            .get_native_function::<<u64 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u64_add_three_async",
             )
             .map_err(|_| {
@@ -1072,11 +1072,11 @@ impl Runtime {
     pub async fn export_primitive_u8_add_three_async_raw(
         &self,
         arg: u8,
-    ) -> Result<u8, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
+            .get_native_function::<<u8 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u8_add_three_async",
             )
             .map_err(|_| {
@@ -1095,11 +1095,11 @@ impl Runtime {
         let result = result.map(|ref data| deserialize_from_slice(data));
         result
     }
-    pub async fn export_reset_global_state_raw(&self) -> Result<(), InvocationError> {
+    pub async fn export_reset_global_state_raw(&self) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<(), ()>("__fp_gen_export_reset_global_state")
+            .get_native_function::<(), FatPtr>("__fp_gen_export_reset_global_state")
             .map_err(|_| {
                 InvocationError::FunctionNotExported(
                     "__fp_gen_export_reset_global_state".to_owned(),

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -448,11 +448,11 @@ impl Runtime {
         let result = result.map(|ref data| deserialize_from_slice(data));
         result
     }
-    pub async fn export_increment_global_state_raw(&self) -> Result<(), InvocationError> {
+    pub async fn export_increment_global_state_raw(&self) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<(), ()>("__fp_gen_export_increment_global_state")
+            .get_native_function::<(), FatPtr>("__fp_gen_export_increment_global_state")
             .map_err(|_| {
                 InvocationError::FunctionNotExported(
                     "__fp_gen_export_increment_global_state".to_owned(),
@@ -527,11 +527,11 @@ impl Runtime {
     pub async fn export_primitive_bool_negate_async_raw(
         &self,
         arg: bool,
-    ) -> Result<bool, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
+            .get_native_function::<<bool as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_bool_negate_async",
             )
             .map_err(|_| {
@@ -577,11 +577,11 @@ impl Runtime {
     pub async fn export_primitive_f32_add_three_async_raw(
         &self,
         arg: f32,
-    ) -> Result<f32, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
+            .get_native_function::<<f32 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_f32_add_three_async",
             )
             .map_err(|_| {
@@ -651,11 +651,11 @@ impl Runtime {
     pub async fn export_primitive_f64_add_three_async_raw(
         &self,
         arg: f64,
-    ) -> Result<f64, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
+            .get_native_function::<<f64 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_f64_add_three_async",
             )
             .map_err(|_| {
@@ -725,11 +725,11 @@ impl Runtime {
     pub async fn export_primitive_i16_add_three_async_raw(
         &self,
         arg: i16,
-    ) -> Result<i16, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
+            .get_native_function::<<i16 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i16_add_three_async",
             )
             .map_err(|_| {
@@ -775,11 +775,11 @@ impl Runtime {
     pub async fn export_primitive_i32_add_three_async_raw(
         &self,
         arg: i32,
-    ) -> Result<i32, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
+            .get_native_function::<<i32 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i32_add_three_async",
             )
             .map_err(|_| {
@@ -825,11 +825,11 @@ impl Runtime {
     pub async fn export_primitive_i64_add_three_async_raw(
         &self,
         arg: i64,
-    ) -> Result<i64, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
+            .get_native_function::<<i64 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i64_add_three_async",
             )
             .map_err(|_| {
@@ -875,11 +875,11 @@ impl Runtime {
     pub async fn export_primitive_i8_add_three_async_raw(
         &self,
         arg: i8,
-    ) -> Result<i8, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
+            .get_native_function::<<i8 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_i8_add_three_async",
             )
             .map_err(|_| {
@@ -925,11 +925,11 @@ impl Runtime {
     pub async fn export_primitive_u16_add_three_async_raw(
         &self,
         arg: u16,
-    ) -> Result<u16, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
+            .get_native_function::<<u16 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u16_add_three_async",
             )
             .map_err(|_| {
@@ -975,11 +975,11 @@ impl Runtime {
     pub async fn export_primitive_u32_add_three_async_raw(
         &self,
         arg: u32,
-    ) -> Result<u32, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
+            .get_native_function::<<u32 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u32_add_three_async",
             )
             .map_err(|_| {
@@ -1025,11 +1025,11 @@ impl Runtime {
     pub async fn export_primitive_u64_add_three_async_raw(
         &self,
         arg: u64,
-    ) -> Result<u64, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
+            .get_native_function::<<u64 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u64_add_three_async",
             )
             .map_err(|_| {
@@ -1075,11 +1075,11 @@ impl Runtime {
     pub async fn export_primitive_u8_add_three_async_raw(
         &self,
         arg: u8,
-    ) -> Result<u8, InvocationError> {
+    ) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
+            .get_native_function::<<u8 as WasmAbi>::AbiType, FatPtr>(
                 "__fp_gen_export_primitive_u8_add_three_async",
             )
             .map_err(|_| {
@@ -1098,11 +1098,11 @@ impl Runtime {
         let result = result.map(|ref data| deserialize_from_slice(data));
         result
     }
-    pub async fn export_reset_global_state_raw(&self) -> Result<(), InvocationError> {
+    pub async fn export_reset_global_state_raw(&self) -> Result<Vec<u8>, InvocationError> {
         let function = self
             .instance
             .exports
-            .get_native_function::<(), ()>("__fp_gen_export_reset_global_state")
+            .get_native_function::<(), FatPtr>("__fp_gen_export_reset_global_state")
             .map_err(|_| {
                 InvocationError::FunctionNotExported(
                     "__fp_gen_export_reset_global_state".to_owned(),

--- a/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer_wasi_runtime_test/expected_bindings.rs
@@ -442,6 +442,27 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_increment_global_state(&self) -> Result<(), InvocationError> {
+        let result = self.export_increment_global_state_raw();
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_increment_global_state_raw(&self) -> Result<(), InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<(), ()>("__fp_gen_export_increment_global_state")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_increment_global_state".to_owned(),
+                )
+            })?;
+        let result = function.call()?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_multiple_primitives(
         &self,
         arg1: i8,
@@ -494,6 +515,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_bool_negate_async(
+        &self,
+        arg: bool,
+    ) -> Result<bool, InvocationError> {
+        let result = self.export_primitive_bool_negate_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_bool_negate_async_raw(
+        &self,
+        arg: bool,
+    ) -> Result<bool, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<bool as WasmAbi>::AbiType, <bool as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_bool_negate_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_bool_negate_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_f32_add_three(&self, arg: f32) -> Result<f32, InvocationError> {
         let result = self.export_primitive_f32_add_three_raw(arg);
         result
@@ -512,6 +562,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_f32_add_three_async(
+        &self,
+        arg: f32,
+    ) -> Result<f32, InvocationError> {
+        let result = self.export_primitive_f32_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_f32_add_three_async_raw(
+        &self,
+        arg: f32,
+    ) -> Result<f32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f32 as WasmAbi>::AbiType, <f32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f32_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f32_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -560,6 +639,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_f64_add_three_async(
+        &self,
+        arg: f64,
+    ) -> Result<f64, InvocationError> {
+        let result = self.export_primitive_f64_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_f64_add_three_async_raw(
+        &self,
+        arg: f64,
+    ) -> Result<f64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<f64 as WasmAbi>::AbiType, <f64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_f64_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_f64_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_f64_add_three_wasmer2(&self, arg: f64) -> Result<f64, InvocationError> {
         let result = self.export_primitive_f64_add_three_wasmer2_raw(arg);
         result
@@ -605,6 +713,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_i16_add_three_async(
+        &self,
+        arg: i16,
+    ) -> Result<i16, InvocationError> {
+        let result = self.export_primitive_i16_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i16_add_three_async_raw(
+        &self,
+        arg: i16,
+    ) -> Result<i16, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i16 as WasmAbi>::AbiType, <i16 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i16_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i16_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_i32_add_three(&self, arg: i32) -> Result<i32, InvocationError> {
         let result = self.export_primitive_i32_add_three_raw(arg);
         result
@@ -623,6 +760,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_i32_add_three_async(
+        &self,
+        arg: i32,
+    ) -> Result<i32, InvocationError> {
+        let result = self.export_primitive_i32_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i32_add_three_async_raw(
+        &self,
+        arg: i32,
+    ) -> Result<i32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i32 as WasmAbi>::AbiType, <i32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i32_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i32_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -647,6 +813,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_i64_add_three_async(
+        &self,
+        arg: i64,
+    ) -> Result<i64, InvocationError> {
+        let result = self.export_primitive_i64_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i64_add_three_async_raw(
+        &self,
+        arg: i64,
+    ) -> Result<i64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i64 as WasmAbi>::AbiType, <i64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i64_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i64_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_i8_add_three(&self, arg: i8) -> Result<i8, InvocationError> {
         let result = self.export_primitive_i8_add_three_raw(arg);
         result
@@ -665,6 +860,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_i8_add_three_async(
+        &self,
+        arg: i8,
+    ) -> Result<i8, InvocationError> {
+        let result = self.export_primitive_i8_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_i8_add_three_async_raw(
+        &self,
+        arg: i8,
+    ) -> Result<i8, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<i8 as WasmAbi>::AbiType, <i8 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_i8_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_i8_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -689,6 +913,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_u16_add_three_async(
+        &self,
+        arg: u16,
+    ) -> Result<u16, InvocationError> {
+        let result = self.export_primitive_u16_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u16_add_three_async_raw(
+        &self,
+        arg: u16,
+    ) -> Result<u16, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u16 as WasmAbi>::AbiType, <u16 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u16_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u16_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_u32_add_three(&self, arg: u32) -> Result<u32, InvocationError> {
         let result = self.export_primitive_u32_add_three_raw(arg);
         result
@@ -707,6 +960,35 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_u32_add_three_async(
+        &self,
+        arg: u32,
+    ) -> Result<u32, InvocationError> {
+        let result = self.export_primitive_u32_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u32_add_three_async_raw(
+        &self,
+        arg: u32,
+    ) -> Result<u32, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u32 as WasmAbi>::AbiType, <u32 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u32_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u32_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -731,6 +1013,35 @@ impl Runtime {
         Ok(result)
     }
 
+    pub async fn export_primitive_u64_add_three_async(
+        &self,
+        arg: u64,
+    ) -> Result<u64, InvocationError> {
+        let result = self.export_primitive_u64_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u64_add_three_async_raw(
+        &self,
+        arg: u64,
+    ) -> Result<u64, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u64 as WasmAbi>::AbiType, <u64 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u64_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u64_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
     pub fn export_primitive_u8_add_three(&self, arg: u8) -> Result<u8, InvocationError> {
         let result = self.export_primitive_u8_add_three_raw(arg);
         result
@@ -749,6 +1060,56 @@ impl Runtime {
             })?;
         let result = function.call(arg.to_abi())?;
         let result = WasmAbi::from_abi(result);
+        Ok(result)
+    }
+
+    pub async fn export_primitive_u8_add_three_async(
+        &self,
+        arg: u8,
+    ) -> Result<u8, InvocationError> {
+        let result = self.export_primitive_u8_add_three_async_raw(arg);
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_primitive_u8_add_three_async_raw(
+        &self,
+        arg: u8,
+    ) -> Result<u8, InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<<u8 as WasmAbi>::AbiType, <u8 as WasmAbi>::AbiType>(
+                "__fp_gen_export_primitive_u8_add_three_async",
+            )
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_primitive_u8_add_three_async".to_owned(),
+                )
+            })?;
+        let result = function.call(arg.to_abi())?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
+        Ok(result)
+    }
+
+    pub async fn export_reset_global_state(&self) -> Result<(), InvocationError> {
+        let result = self.export_reset_global_state_raw();
+        let result = result.await;
+        let result = result.map(|ref data| deserialize_from_slice(data));
+        result
+    }
+    pub async fn export_reset_global_state_raw(&self) -> Result<(), InvocationError> {
+        let function = self
+            .instance
+            .exports
+            .get_native_function::<(), ()>("__fp_gen_export_reset_global_state")
+            .map_err(|_| {
+                InvocationError::FunctionNotExported(
+                    "__fp_gen_export_reset_global_state".to_owned(),
+                )
+            })?;
+        let result = function.call()?;
+        let result = ModuleRawFuture::new(self.env.clone(), result).await;
         Ok(result)
     }
 
@@ -1119,6 +1480,10 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> wasmer::Exp
         Function::new_native_with_env(store, env.clone(), _import_get_serde_bytes),
     );
     namespace.insert(
+        "__fp_gen_import_increment_global_state",
+        Function::new_native_with_env(store, env.clone(), _import_increment_global_state),
+    );
+    namespace.insert(
         "__fp_gen_import_multiple_primitives",
         Function::new_native_with_env(store, env.clone(), _import_multiple_primitives),
     );
@@ -1127,8 +1492,16 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> wasmer::Exp
         Function::new_native_with_env(store, env.clone(), _import_primitive_bool_negate),
     );
     namespace.insert(
+        "__fp_gen_import_primitive_bool_negate_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_bool_negate_async),
+    );
+    namespace.insert(
         "__fp_gen_import_primitive_f32_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_f32_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_f32_add_one_async),
     );
     namespace.insert(
         "__fp_gen_import_primitive_f32_add_one_wasmer2",
@@ -1139,6 +1512,10 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> wasmer::Exp
         Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one),
     );
     namespace.insert(
+        "__fp_gen_import_primitive_f64_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one_async),
+    );
+    namespace.insert(
         "__fp_gen_import_primitive_f64_add_one_wasmer2",
         Function::new_native_with_env(store, env.clone(), _import_primitive_f64_add_one_wasmer2),
     );
@@ -1147,32 +1524,68 @@ fn create_import_object(store: &Store, env: &RuntimeInstanceData) -> wasmer::Exp
         Function::new_native_with_env(store, env.clone(), _import_primitive_i16_add_one),
     );
     namespace.insert(
+        "__fp_gen_import_primitive_i16_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i16_add_one_async),
+    );
+    namespace.insert(
         "__fp_gen_import_primitive_i32_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_i32_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_i32_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i32_add_one_async),
     );
     namespace.insert(
         "__fp_gen_import_primitive_i64_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_i64_add_one),
     );
     namespace.insert(
+        "__fp_gen_import_primitive_i64_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i64_add_one_async),
+    );
+    namespace.insert(
         "__fp_gen_import_primitive_i8_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_i8_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_i8_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_i8_add_one_async),
     );
     namespace.insert(
         "__fp_gen_import_primitive_u16_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_u16_add_one),
     );
     namespace.insert(
+        "__fp_gen_import_primitive_u16_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u16_add_one_async),
+    );
+    namespace.insert(
         "__fp_gen_import_primitive_u32_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_u32_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_u32_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u32_add_one_async),
     );
     namespace.insert(
         "__fp_gen_import_primitive_u64_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_u64_add_one),
     );
     namespace.insert(
+        "__fp_gen_import_primitive_u64_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u64_add_one_async),
+    );
+    namespace.insert(
         "__fp_gen_import_primitive_u8_add_one",
         Function::new_native_with_env(store, env.clone(), _import_primitive_u8_add_one),
+    );
+    namespace.insert(
+        "__fp_gen_import_primitive_u8_add_one_async",
+        Function::new_native_with_env(store, env.clone(), _import_primitive_u8_add_one_async),
+    );
+    namespace.insert(
+        "__fp_gen_import_reset_global_state",
+        Function::new_native_with_env(store, env.clone(), _import_reset_global_state),
     );
     namespace.insert(
         "__fp_gen_import_serde_adjacently_tagged",
@@ -1338,6 +1751,19 @@ pub fn _import_get_serde_bytes(env: &RuntimeInstanceData) -> FatPtr {
     export_to_guest(env, &result)
 }
 
+pub fn _import_increment_global_state(env: &RuntimeInstanceData) -> FatPtr {
+    let result = super::import_increment_global_state();
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_multiple_primitives(
     env: &RuntimeInstanceData,
     arg1: <i8 as WasmAbi>::AbiType,
@@ -1358,6 +1784,23 @@ pub fn _import_primitive_bool_negate(
     result.to_abi()
 }
 
+pub fn _import_primitive_bool_negate_async(
+    env: &RuntimeInstanceData,
+    arg: <bool as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_bool_negate_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_f32_add_one(
     env: &RuntimeInstanceData,
     arg: <f32 as WasmAbi>::AbiType,
@@ -1365,6 +1808,23 @@ pub fn _import_primitive_f32_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_f32_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_f32_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <f32 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_f32_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_f32_add_one_wasmer2(
@@ -1385,6 +1845,23 @@ pub fn _import_primitive_f64_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_f64_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <f64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_f64_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_f64_add_one_wasmer2(
     env: &RuntimeInstanceData,
     arg: FatPtr,
@@ -1403,6 +1880,23 @@ pub fn _import_primitive_i16_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_i16_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i16 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i16_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_i32_add_one(
     env: &RuntimeInstanceData,
     arg: <i32 as WasmAbi>::AbiType,
@@ -1410,6 +1904,23 @@ pub fn _import_primitive_i32_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_i32_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_i32_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i32 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i32_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_i64_add_one(
@@ -1421,6 +1932,23 @@ pub fn _import_primitive_i64_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_i64_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i64_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_i8_add_one(
     env: &RuntimeInstanceData,
     arg: <i8 as WasmAbi>::AbiType,
@@ -1428,6 +1956,23 @@ pub fn _import_primitive_i8_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_i8_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_i8_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <i8 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_i8_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_u16_add_one(
@@ -1439,6 +1984,23 @@ pub fn _import_primitive_u16_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_u16_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u16 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u16_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_u32_add_one(
     env: &RuntimeInstanceData,
     arg: <u32 as WasmAbi>::AbiType,
@@ -1446,6 +2008,23 @@ pub fn _import_primitive_u32_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_u32_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_u32_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u32 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u32_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_primitive_u64_add_one(
@@ -1457,6 +2036,23 @@ pub fn _import_primitive_u64_add_one(
     result.to_abi()
 }
 
+pub fn _import_primitive_u64_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u64 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u64_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
 pub fn _import_primitive_u8_add_one(
     env: &RuntimeInstanceData,
     arg: <u8 as WasmAbi>::AbiType,
@@ -1464,6 +2060,36 @@ pub fn _import_primitive_u8_add_one(
     let arg = WasmAbi::from_abi(arg);
     let result = super::import_primitive_u8_add_one(arg);
     result.to_abi()
+}
+
+pub fn _import_primitive_u8_add_one_async(
+    env: &RuntimeInstanceData,
+    arg: <u8 as WasmAbi>::AbiType,
+) -> FatPtr {
+    let arg = WasmAbi::from_abi(arg);
+    let result = super::import_primitive_u8_add_one_async(arg);
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
+}
+
+pub fn _import_reset_global_state(env: &RuntimeInstanceData) -> FatPtr {
+    let result = super::import_reset_global_state();
+    let env = env.clone();
+    let async_ptr = create_future_value(&env);
+    let handle = tokio::runtime::Handle::current();
+    handle.spawn(async move {
+        let result = result.await;
+        let result_ptr = export_to_guest(&env, &result);
+        env.guest_resolve_async_value(async_ptr, result_ptr);
+    });
+    async_ptr
 }
 
 pub fn _import_serde_adjacently_tagged(env: &RuntimeInstanceData, arg: FatPtr) -> FatPtr {

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -30,20 +30,33 @@ export type Imports = {
     importGenerics: (arg: types.StructWithGenerics<number>) => types.StructWithGenerics<number>;
     importGetBytes: () => types.Result<Uint8Array, string>;
     importGetSerdeBytes: () => types.Result<ArrayBuffer, string>;
+    importIncrementGlobalState: () => Promise<void>;
     importMultiplePrimitives: (arg1: number, arg2: string) => bigint;
     importPrimitiveBoolNegate: (arg: boolean) => boolean;
+    importPrimitiveBoolNegateAsync: (arg: boolean) => Promise<boolean>;
     importPrimitiveF32AddOne: (arg: number) => number;
+    importPrimitiveF32AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveF32AddOneWasmer2: (arg: Float32Array) => number;
     importPrimitiveF64AddOne: (arg: number) => number;
+    importPrimitiveF64AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveF64AddOneWasmer2: (arg: Float64Array) => number;
     importPrimitiveI16AddOne: (arg: number) => number;
+    importPrimitiveI16AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveI32AddOne: (arg: number) => number;
+    importPrimitiveI32AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveI64AddOne: (arg: bigint) => bigint;
+    importPrimitiveI64AddOneAsync: (arg: bigint) => Promise<number>;
     importPrimitiveI8AddOne: (arg: number) => number;
+    importPrimitiveI8AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveU16AddOne: (arg: number) => number;
+    importPrimitiveU16AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveU32AddOne: (arg: number) => number;
+    importPrimitiveU32AddOneAsync: (arg: number) => Promise<number>;
     importPrimitiveU64AddOne: (arg: bigint) => bigint;
+    importPrimitiveU64AddOneAsync: (arg: bigint) => Promise<number>;
     importPrimitiveU8AddOne: (arg: number) => number;
+    importPrimitiveU8AddOneAsync: (arg: number) => Promise<number>;
+    importResetGlobalState: () => Promise<void>;
     importSerdeAdjacentlyTagged: (arg: types.SerdeAdjacentlyTagged) => types.SerdeAdjacentlyTagged;
     importSerdeEnum: (arg: types.SerdeVariantRenaming) => types.SerdeVariantRenaming;
     importSerdeFlatten: (arg: types.SerdeFlatten) => types.SerdeFlatten;
@@ -79,20 +92,33 @@ export type Exports = {
     exportGenerics?: (arg: types.StructWithGenerics<number>) => types.StructWithGenerics<number>;
     exportGetBytes?: () => types.Result<Uint8Array, string>;
     exportGetSerdeBytes?: () => types.Result<ArrayBuffer, string>;
+    exportIncrementGlobalState?: () => Promise<void>;
     exportMultiplePrimitives?: (arg1: number, arg2: string) => bigint;
     exportPrimitiveBoolNegate?: (arg: boolean) => boolean;
+    exportPrimitiveBoolNegateAsync?: (arg: boolean) => Promise<boolean>;
     exportPrimitiveF32AddThree?: (arg: number) => number;
+    exportPrimitiveF32AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveF32AddThreeWasmer2?: (arg: number) => number;
     exportPrimitiveF64AddThree?: (arg: number) => number;
+    exportPrimitiveF64AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveF64AddThreeWasmer2?: (arg: number) => number;
     exportPrimitiveI16AddThree?: (arg: number) => number;
+    exportPrimitiveI16AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveI32AddThree?: (arg: number) => number;
+    exportPrimitiveI32AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveI64AddThree?: (arg: bigint) => bigint;
+    exportPrimitiveI64AddThreeAsync?: (arg: bigint) => Promise<number>;
     exportPrimitiveI8AddThree?: (arg: number) => number;
+    exportPrimitiveI8AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveU16AddThree?: (arg: number) => number;
+    exportPrimitiveU16AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveU32AddThree?: (arg: number) => number;
+    exportPrimitiveU32AddThreeAsync?: (arg: number) => Promise<number>;
     exportPrimitiveU64AddThree?: (arg: bigint) => bigint;
+    exportPrimitiveU64AddThreeAsync?: (arg: bigint) => Promise<number>;
     exportPrimitiveU8AddThree?: (arg: number) => number;
+    exportPrimitiveU8AddThreeAsync?: (arg: number) => Promise<number>;
+    exportResetGlobalState?: () => Promise<void>;
     exportSerdeAdjacentlyTagged?: (arg: types.SerdeAdjacentlyTagged) => types.SerdeAdjacentlyTagged;
     exportSerdeEnum?: (arg: types.SerdeVariantRenaming) => types.SerdeVariantRenaming;
     exportSerdeFlatten?: (arg: types.SerdeFlatten) => types.SerdeFlatten;
@@ -124,12 +150,25 @@ export type Exports = {
     exportGenericsRaw?: (arg: Uint8Array) => Uint8Array;
     exportGetBytesRaw?: () => Uint8Array;
     exportGetSerdeBytesRaw?: () => Uint8Array;
+    exportIncrementGlobalStateRaw?: () => Promise<void>;
     exportMultiplePrimitivesRaw?: (arg1: number, arg2: Uint8Array) => bigint;
     exportPrimitiveBoolNegateRaw?: (arg: boolean) => boolean;
+    exportPrimitiveBoolNegateAsyncRaw?: (arg: boolean) => Promise<boolean>;
+    exportPrimitiveF32AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveF64AddThreeAsyncRaw?: (arg: number) => Promise<number>;
     exportPrimitiveI16AddThreeRaw?: (arg: number) => number;
+    exportPrimitiveI16AddThreeAsyncRaw?: (arg: number) => Promise<number>;
     exportPrimitiveI32AddThreeRaw?: (arg: number) => number;
+    exportPrimitiveI32AddThreeAsyncRaw?: (arg: number) => Promise<number>;
     exportPrimitiveI64AddThreeRaw?: (arg: bigint) => bigint;
+    exportPrimitiveI64AddThreeAsyncRaw?: (arg: bigint) => Promise<bigint>;
     exportPrimitiveI8AddThreeRaw?: (arg: number) => number;
+    exportPrimitiveI8AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveU16AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveU32AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveU64AddThreeAsyncRaw?: (arg: bigint) => Promise<bigint>;
+    exportPrimitiveU8AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportResetGlobalStateRaw?: () => Promise<void>;
     exportSerdeAdjacentlyTaggedRaw?: (arg: Uint8Array) => Uint8Array;
     exportSerdeEnumRaw?: (arg: Uint8Array) => Uint8Array;
     exportSerdeFlattenRaw?: (arg: Uint8Array) => Uint8Array;
@@ -328,6 +367,20 @@ export async function createRuntime(
             __fp_gen_import_get_serde_bytes: (): FatPtr => {
                 return serializeObject(importFunctions.importGetSerdeBytes());
             },
+            __fp_gen_import_increment_global_state: () => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importIncrementGlobalState()
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, 0);
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_increment_global_state"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_multiple_primitives: (arg1: number, arg2_ptr: FatPtr): bigint => {
                 const arg2 = parseObject<string>(arg2_ptr);
                 return interpretBigSign(importFunctions.importMultiplePrimitives(arg1, arg2), 9223372036854775808n);
@@ -335,8 +388,36 @@ export async function createRuntime(
             __fp_gen_import_primitive_bool_negate: (arg: boolean): boolean => {
                 return !!importFunctions.importPrimitiveBoolNegate(arg);
             },
+            __fp_gen_import_primitive_bool_negate_async: (arg: boolean): boolean => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveBoolNegateAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_bool_negate_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_primitive_f32_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveF32AddOne(arg);
+            },
+            __fp_gen_import_primitive_f32_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveF32AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_f32_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
             },
             __fp_gen_import_primitive_f32_add_one_wasmer2: (arg_ptr: FatPtr): number => {
                 const arg = parseObject<Float32Array>(arg_ptr);
@@ -345,6 +426,20 @@ export async function createRuntime(
             __fp_gen_import_primitive_f64_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveF64AddOne(arg);
             },
+            __fp_gen_import_primitive_f64_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveF64AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_f64_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_primitive_f64_add_one_wasmer2: (arg_ptr: FatPtr): number => {
                 const arg = parseObject<Float64Array>(arg_ptr);
                 return importFunctions.importPrimitiveF64AddOneWasmer2(arg);
@@ -352,26 +447,152 @@ export async function createRuntime(
             __fp_gen_import_primitive_i16_add_one: (arg: number): number => {
                 return interpretSign(importFunctions.importPrimitiveI16AddOne(arg), 32768);
             },
+            __fp_gen_import_primitive_i16_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveI16AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_i16_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_primitive_i32_add_one: (arg: number): number => {
                 return interpretSign(importFunctions.importPrimitiveI32AddOne(arg), 2147483648);
+            },
+            __fp_gen_import_primitive_i32_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveI32AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_i32_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
             },
             __fp_gen_import_primitive_i64_add_one: (arg: bigint): bigint => {
                 return interpretBigSign(importFunctions.importPrimitiveI64AddOne(arg), 9223372036854775808n);
             },
+            __fp_gen_import_primitive_i64_add_one_async: (arg: bigint): bigint => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveI64AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_i64_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_primitive_i8_add_one: (arg: number): number => {
                 return interpretSign(importFunctions.importPrimitiveI8AddOne(arg), 128);
+            },
+            __fp_gen_import_primitive_i8_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveI8AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_i8_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
             },
             __fp_gen_import_primitive_u16_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveU16AddOne(arg);
             },
+            __fp_gen_import_primitive_u16_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveU16AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_u16_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_primitive_u32_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveU32AddOne(arg);
+            },
+            __fp_gen_import_primitive_u32_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveU32AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_u32_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
             },
             __fp_gen_import_primitive_u64_add_one: (arg: bigint): bigint => {
                 return importFunctions.importPrimitiveU64AddOne(arg);
             },
+            __fp_gen_import_primitive_u64_add_one_async: (arg: bigint): bigint => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveU64AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_u64_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
             __fp_gen_import_primitive_u8_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveU8AddOne(arg);
+            },
+            __fp_gen_import_primitive_u8_add_one_async: (arg: number): number => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importPrimitiveU8AddOneAsync(arg)
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, serializeObject(result));
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_primitive_u8_add_one_async"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
+            },
+            __fp_gen_import_reset_global_state: () => {
+                const _async_result_ptr = createAsyncValue();
+                importFunctions.importResetGlobalState()
+                    .then((result) => {
+                        resolveFuture(_async_result_ptr, 0);
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Unrecoverable exception trying to call async host function "import_reset_global_state"',
+                            error
+                        );
+                    });
+                return _async_result_ptr;
             },
             __fp_gen_import_serde_adjacently_tagged: (arg_ptr: FatPtr): FatPtr => {
                 const arg = parseObject<types.SerdeAdjacentlyTagged>(arg_ptr);
@@ -611,6 +832,12 @@ export async function createRuntime(
 
             return () => parseObject<types.Result<ArrayBuffer, string>>(export_fn());
         })(),
+        exportIncrementGlobalState: (() => {
+            const export_fn = instance.exports.__fp_gen_export_increment_global_state as any;
+            if (!export_fn) return;
+
+            return () => promiseFromPtr(export_fn()).then((ptr) => parseObject<void>(ptr));
+        })(),
         exportMultiplePrimitives: (() => {
             const export_fn = instance.exports.__fp_gen_export_multiple_primitives as any;
             if (!export_fn) return;
@@ -626,9 +853,27 @@ export async function createRuntime(
 
             return (arg: boolean) => !!export_fn(arg);
         })(),
+        exportPrimitiveBoolNegateAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_bool_negate_async as any;
+            if (!export_fn) return;
+
+            return (arg: boolean) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<boolean>(ptr));
+        })(),
         exportPrimitiveF32AddThree: instance.exports.__fp_gen_export_primitive_f32_add_three as any,
+        exportPrimitiveF32AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_f32_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveF32AddThreeWasmer2: instance.exports.__fp_gen_export_primitive_f32_add_three_wasmer2 as any,
         exportPrimitiveF64AddThree: instance.exports.__fp_gen_export_primitive_f64_add_three as any,
+        exportPrimitiveF64AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_f64_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveF64AddThreeWasmer2: instance.exports.__fp_gen_export_primitive_f64_add_three_wasmer2 as any,
         exportPrimitiveI16AddThree: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i16_add_three as any;
@@ -636,11 +881,23 @@ export async function createRuntime(
 
             return (arg: number) => interpretSign(export_fn(arg), 32768);
         })(),
+        exportPrimitiveI16AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i16_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveI32AddThree: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i32_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 2147483648);
+        })(),
+        exportPrimitiveI32AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i32_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
         })(),
         exportPrimitiveI64AddThree: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i64_add_three as any;
@@ -648,16 +905,58 @@ export async function createRuntime(
 
             return (arg: bigint) => interpretBigSign(export_fn(arg), 9223372036854775808n);
         })(),
+        exportPrimitiveI64AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i64_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: bigint) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveI8AddThree: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i8_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 128);
         })(),
+        exportPrimitiveI8AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i8_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveU16AddThree: instance.exports.__fp_gen_export_primitive_u16_add_three as any,
+        exportPrimitiveU16AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u16_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveU32AddThree: instance.exports.__fp_gen_export_primitive_u32_add_three as any,
+        exportPrimitiveU32AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u32_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveU64AddThree: instance.exports.__fp_gen_export_primitive_u64_add_three as any,
+        exportPrimitiveU64AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u64_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: bigint) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
         exportPrimitiveU8AddThree: instance.exports.__fp_gen_export_primitive_u8_add_three as any,
+        exportPrimitiveU8AddThreeAsync: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u8_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then((ptr) => parseObject<number>(ptr));
+        })(),
+        exportResetGlobalState: (() => {
+            const export_fn = instance.exports.__fp_gen_export_reset_global_state as any;
+            if (!export_fn) return;
+
+            return () => promiseFromPtr(export_fn()).then((ptr) => parseObject<void>(ptr));
+        })(),
         exportSerdeAdjacentlyTagged: (() => {
             const export_fn = instance.exports.__fp_gen_export_serde_adjacently_tagged as any;
             if (!export_fn) return;
@@ -915,6 +1214,12 @@ export async function createRuntime(
 
             return () => importFromMemory(export_fn());
         })(),
+        exportIncrementGlobalStateRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_increment_global_state as any;
+            if (!export_fn) return;
+
+            return () => promiseFromPtr(export_fn()).then(importFromMemory);
+        })(),
         exportMultiplePrimitivesRaw: (() => {
             const export_fn = instance.exports.__fp_gen_export_multiple_primitives as any;
             if (!export_fn) return;
@@ -930,11 +1235,35 @@ export async function createRuntime(
 
             return (arg: boolean) => !!export_fn(arg);
         })(),
+        exportPrimitiveBoolNegateAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_bool_negate_async as any;
+            if (!export_fn) return;
+
+            return (arg: boolean) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportPrimitiveF32AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_f32_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportPrimitiveF64AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_f64_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
         exportPrimitiveI16AddThreeRaw: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i16_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 32768);
+        })(),
+        exportPrimitiveI16AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i16_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
         })(),
         exportPrimitiveI32AddThreeRaw: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i32_add_three as any;
@@ -942,17 +1271,65 @@ export async function createRuntime(
 
             return (arg: number) => interpretSign(export_fn(arg), 2147483648);
         })(),
+        exportPrimitiveI32AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i32_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
         exportPrimitiveI64AddThreeRaw: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i64_add_three as any;
             if (!export_fn) return;
 
             return (arg: bigint) => interpretBigSign(export_fn(arg), 9223372036854775808n);
         })(),
+        exportPrimitiveI64AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i64_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: bigint) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
         exportPrimitiveI8AddThreeRaw: (() => {
             const export_fn = instance.exports.__fp_gen_export_primitive_i8_add_three as any;
             if (!export_fn) return;
 
             return (arg: number) => interpretSign(export_fn(arg), 128);
+        })(),
+        exportPrimitiveI8AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_i8_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportPrimitiveU16AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u16_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportPrimitiveU32AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u32_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportPrimitiveU64AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u64_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: bigint) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportPrimitiveU8AddThreeAsyncRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_primitive_u8_add_three_async as any;
+            if (!export_fn) return;
+
+            return (arg: number) => promiseFromPtr(export_fn(arg)).then(importFromMemory);
+        })(),
+        exportResetGlobalStateRaw: (() => {
+            const export_fn = instance.exports.__fp_gen_export_reset_global_state as any;
+            if (!export_fn) return;
+
+            return () => promiseFromPtr(export_fn()).then(importFromMemory);
         })(),
         exportSerdeAdjacentlyTaggedRaw: (() => {
             const export_fn = instance.exports.__fp_gen_export_serde_adjacently_tagged as any;

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -150,25 +150,25 @@ export type Exports = {
     exportGenericsRaw?: (arg: Uint8Array) => Uint8Array;
     exportGetBytesRaw?: () => Uint8Array;
     exportGetSerdeBytesRaw?: () => Uint8Array;
-    exportIncrementGlobalStateRaw?: () => Promise<void>;
+    exportIncrementGlobalStateRaw?: () => Promise<Uint8Array>;
     exportMultiplePrimitivesRaw?: (arg1: number, arg2: Uint8Array) => bigint;
     exportPrimitiveBoolNegateRaw?: (arg: boolean) => boolean;
-    exportPrimitiveBoolNegateAsyncRaw?: (arg: boolean) => Promise<boolean>;
-    exportPrimitiveF32AddThreeAsyncRaw?: (arg: number) => Promise<number>;
-    exportPrimitiveF64AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveBoolNegateAsyncRaw?: (arg: boolean) => Promise<Uint8Array>;
+    exportPrimitiveF32AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
+    exportPrimitiveF64AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
     exportPrimitiveI16AddThreeRaw?: (arg: number) => number;
-    exportPrimitiveI16AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveI16AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
     exportPrimitiveI32AddThreeRaw?: (arg: number) => number;
-    exportPrimitiveI32AddThreeAsyncRaw?: (arg: number) => Promise<number>;
+    exportPrimitiveI32AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
     exportPrimitiveI64AddThreeRaw?: (arg: bigint) => bigint;
-    exportPrimitiveI64AddThreeAsyncRaw?: (arg: bigint) => Promise<bigint>;
+    exportPrimitiveI64AddThreeAsyncRaw?: (arg: bigint) => Promise<Uint8Array>;
     exportPrimitiveI8AddThreeRaw?: (arg: number) => number;
-    exportPrimitiveI8AddThreeAsyncRaw?: (arg: number) => Promise<number>;
-    exportPrimitiveU16AddThreeAsyncRaw?: (arg: number) => Promise<number>;
-    exportPrimitiveU32AddThreeAsyncRaw?: (arg: number) => Promise<number>;
-    exportPrimitiveU64AddThreeAsyncRaw?: (arg: bigint) => Promise<bigint>;
-    exportPrimitiveU8AddThreeAsyncRaw?: (arg: number) => Promise<number>;
-    exportResetGlobalStateRaw?: () => Promise<void>;
+    exportPrimitiveI8AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
+    exportPrimitiveU16AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
+    exportPrimitiveU32AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
+    exportPrimitiveU64AddThreeAsyncRaw?: (arg: bigint) => Promise<Uint8Array>;
+    exportPrimitiveU8AddThreeAsyncRaw?: (arg: number) => Promise<Uint8Array>;
+    exportResetGlobalStateRaw?: () => Promise<Uint8Array>;
     exportSerdeAdjacentlyTaggedRaw?: (arg: Uint8Array) => Uint8Array;
     exportSerdeEnumRaw?: (arg: Uint8Array) => Uint8Array;
     exportSerdeFlattenRaw?: (arg: Uint8Array) => Uint8Array;
@@ -367,11 +367,11 @@ export async function createRuntime(
             __fp_gen_import_get_serde_bytes: (): FatPtr => {
                 return serializeObject(importFunctions.importGetSerdeBytes());
             },
-            __fp_gen_import_increment_global_state: () => {
+            __fp_gen_import_increment_global_state: (): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importIncrementGlobalState()
                     .then((result) => {
-                        resolveFuture(_async_result_ptr, 0);
+                        resolveFuture(_async_result_ptr, serializeObject(result));
                     })
                     .catch((error) => {
                         console.error(
@@ -388,7 +388,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_bool_negate: (arg: boolean): boolean => {
                 return !!importFunctions.importPrimitiveBoolNegate(arg);
             },
-            __fp_gen_import_primitive_bool_negate_async: (arg: boolean): boolean => {
+            __fp_gen_import_primitive_bool_negate_async: (arg: boolean): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveBoolNegateAsync(arg)
                     .then((result) => {
@@ -405,7 +405,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_f32_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveF32AddOne(arg);
             },
-            __fp_gen_import_primitive_f32_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_f32_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveF32AddOneAsync(arg)
                     .then((result) => {
@@ -426,7 +426,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_f64_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveF64AddOne(arg);
             },
-            __fp_gen_import_primitive_f64_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_f64_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveF64AddOneAsync(arg)
                     .then((result) => {
@@ -447,7 +447,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_i16_add_one: (arg: number): number => {
                 return interpretSign(importFunctions.importPrimitiveI16AddOne(arg), 32768);
             },
-            __fp_gen_import_primitive_i16_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_i16_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveI16AddOneAsync(arg)
                     .then((result) => {
@@ -464,7 +464,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_i32_add_one: (arg: number): number => {
                 return interpretSign(importFunctions.importPrimitiveI32AddOne(arg), 2147483648);
             },
-            __fp_gen_import_primitive_i32_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_i32_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveI32AddOneAsync(arg)
                     .then((result) => {
@@ -481,7 +481,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_i64_add_one: (arg: bigint): bigint => {
                 return interpretBigSign(importFunctions.importPrimitiveI64AddOne(arg), 9223372036854775808n);
             },
-            __fp_gen_import_primitive_i64_add_one_async: (arg: bigint): bigint => {
+            __fp_gen_import_primitive_i64_add_one_async: (arg: bigint): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveI64AddOneAsync(arg)
                     .then((result) => {
@@ -498,7 +498,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_i8_add_one: (arg: number): number => {
                 return interpretSign(importFunctions.importPrimitiveI8AddOne(arg), 128);
             },
-            __fp_gen_import_primitive_i8_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_i8_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveI8AddOneAsync(arg)
                     .then((result) => {
@@ -515,7 +515,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_u16_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveU16AddOne(arg);
             },
-            __fp_gen_import_primitive_u16_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_u16_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveU16AddOneAsync(arg)
                     .then((result) => {
@@ -532,7 +532,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_u32_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveU32AddOne(arg);
             },
-            __fp_gen_import_primitive_u32_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_u32_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveU32AddOneAsync(arg)
                     .then((result) => {
@@ -549,7 +549,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_u64_add_one: (arg: bigint): bigint => {
                 return importFunctions.importPrimitiveU64AddOne(arg);
             },
-            __fp_gen_import_primitive_u64_add_one_async: (arg: bigint): bigint => {
+            __fp_gen_import_primitive_u64_add_one_async: (arg: bigint): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveU64AddOneAsync(arg)
                     .then((result) => {
@@ -566,7 +566,7 @@ export async function createRuntime(
             __fp_gen_import_primitive_u8_add_one: (arg: number): number => {
                 return importFunctions.importPrimitiveU8AddOne(arg);
             },
-            __fp_gen_import_primitive_u8_add_one_async: (arg: number): number => {
+            __fp_gen_import_primitive_u8_add_one_async: (arg: number): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importPrimitiveU8AddOneAsync(arg)
                     .then((result) => {
@@ -580,11 +580,11 @@ export async function createRuntime(
                     });
                 return _async_result_ptr;
             },
-            __fp_gen_import_reset_global_state: () => {
+            __fp_gen_import_reset_global_state: (): FatPtr => {
                 const _async_result_ptr = createAsyncValue();
                 importFunctions.importResetGlobalState()
                     .then((result) => {
-                        resolveFuture(_async_result_ptr, 0);
+                        resolveFuture(_async_result_ptr, serializeObject(result));
                     })
                     .catch((error) => {
                         console.error(

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -124,6 +124,19 @@ fp_import! {
     fn import_serde_adjacently_tagged(arg: SerdeAdjacentlyTagged) -> SerdeAdjacentlyTagged;
     fn import_serde_untagged(arg: SerdeUntagged) -> SerdeUntagged;
 
+    // Passing primitives as async:
+    async fn import_primitive_bool_negate_async(arg: bool) -> bool;
+    async fn import_primitive_f32_add_one_async(arg: f32) -> f32;
+    async fn import_primitive_f64_add_one_async(arg: f64) -> f64;
+    async fn import_primitive_i8_add_one_async(arg: i8) -> i8;
+    async fn import_primitive_i16_add_one_async(arg: i16) -> i16;
+    async fn import_primitive_i32_add_one_async(arg: i32) -> i32;
+    async fn import_primitive_i64_add_one_async(arg: i64) -> i64;
+    async fn import_primitive_u8_add_one_async(arg: u8) -> u8;
+    async fn import_primitive_u16_add_one_async(arg: u16) -> u16;
+    async fn import_primitive_u32_add_one_async(arg: u32) -> u32;
+    async fn import_primitive_u64_add_one_async(arg: u64) -> u64;
+
     // Async function:
     async fn import_fp_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming;
 
@@ -213,6 +226,19 @@ fp_export! {
     fn export_serde_internally_tagged(arg: SerdeInternallyTagged) -> SerdeInternallyTagged;
     fn export_serde_adjacently_tagged(arg: SerdeAdjacentlyTagged) -> SerdeAdjacentlyTagged;
     fn export_serde_untagged(arg: SerdeUntagged) -> SerdeUntagged;
+
+    // Passing primitives with async:
+    async fn export_primitive_bool_negate_async(arg: bool) -> bool;
+    async fn export_primitive_f32_add_three_async(arg: f32) -> f32;
+    async fn export_primitive_f64_add_three_async(arg: f64) -> f64;
+    async fn export_primitive_i8_add_three_async(arg: i8) -> i8;
+    async fn export_primitive_i16_add_three_async(arg: i16) -> i16;
+    async fn export_primitive_i32_add_three_async(arg: i32) -> i32;
+    async fn export_primitive_i64_add_three_async(arg: i64) -> i64;
+    async fn export_primitive_u8_add_three_async(arg: u8) -> u8;
+    async fn export_primitive_u16_add_three_async(arg: u16) -> u16;
+    async fn export_primitive_u32_add_three_async(arg: u32) -> u32;
+    async fn export_primitive_u64_add_three_async(arg: u64) -> u64;
 
     // Async function:
     async fn export_async_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming;

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -137,6 +137,11 @@ fp_import! {
     async fn import_primitive_u32_add_one_async(arg: u32) -> u32;
     async fn import_primitive_u64_add_one_async(arg: u64) -> u64;
 
+    // Test that void return works with async as well.
+    // Intentionally explicit unit struct return in only one declaration, to test both variants.
+    async fn import_reset_global_state() -> ();
+    async fn import_increment_global_state();
+
     // Async function:
     async fn import_fp_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming;
 
@@ -239,6 +244,11 @@ fp_export! {
     async fn export_primitive_u16_add_three_async(arg: u16) -> u16;
     async fn export_primitive_u32_add_three_async(arg: u32) -> u32;
     async fn export_primitive_u64_add_three_async(arg: u64) -> u64;
+
+    // Test that void return works with async as well.
+    // Intentionally explicit unit struct return in only one declaration, to test both variants.
+    async fn export_reset_global_state() -> ();
+    async fn export_increment_global_state();
 
     // Async function:
     async fn export_async_struct(arg1: FpPropertyRenaming, arg2: u64) -> FpPropertyRenaming;

--- a/examples/example-rust-wasmer-runtime/src/main.rs
+++ b/examples/example-rust-wasmer-runtime/src/main.rs
@@ -1,7 +1,11 @@
 mod spec;
-mod wasi_spec;
 #[cfg(test)]
 mod test;
+mod wasi_spec;
+
+use std::sync::Mutex;
+
+pub static GLOBAL_STATE: Mutex<u32> = Mutex::new(0);
 
 fn main() {
     println!("Hello, world!");

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -185,7 +185,7 @@ fn log(msg: String) {
 
 async fn make_http_request(opts: Request) -> Result<Response, RequestError> {
     Ok(Response {
-        body: ByteBuf::from(r#"status: "confirmed""#.to_string()),
+        body: ByteBuf::from(r#"{"status":"confirmed"}"#.to_string()),
         headers: opts.headers,
         status_code: 200,
     })

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -141,6 +141,40 @@ fn import_serde_untagged(arg: SerdeUntagged) -> SerdeUntagged {
     todo!()
 }
 
+async fn import_primitive_bool_negate_async(arg: bool) -> bool {
+    !arg
+}
+async fn import_primitive_f32_add_one_async(arg: f32) -> f32 {
+    arg + 1.0
+}
+async fn import_primitive_f64_add_one_async(arg: f64) -> f64 {
+    arg + 1.0
+}
+async fn import_primitive_i8_add_one_async(arg: i8) -> i8 {
+    arg + 1
+}
+async fn import_primitive_i16_add_one_async(arg: i16) -> i16 {
+    arg + 1
+}
+async fn import_primitive_i32_add_one_async(arg: i32) -> i32 {
+    arg + 1
+}
+async fn import_primitive_i64_add_one_async(arg: i64) -> i64 {
+    arg + 1
+}
+async fn import_primitive_u8_add_one_async(arg: u8) -> u8 {
+    arg + 1
+}
+async fn import_primitive_u16_add_one_async(arg: u16) -> u16 {
+    arg + 1
+}
+async fn import_primitive_u32_add_one_async(arg: u32) -> u32 {
+    arg + 1
+}
+async fn import_primitive_u64_add_one_async(arg: u64) -> u64 {
+    arg + 1
+}
+
 fn import_struct_with_options(arg: StructWithOptions) {
     todo!()
 }

--- a/examples/example-rust-wasmer-runtime/src/spec/mod.rs
+++ b/examples/example-rust-wasmer-runtime/src/spec/mod.rs
@@ -4,6 +4,7 @@ pub mod types;
 use bytes::Bytes;
 use serde_bytes::ByteBuf;
 use types::*;
+use super::GLOBAL_STATE;
 
 fn import_void_function() {}
 fn import_void_function_empty_result() -> Result<(), u32> {
@@ -173,6 +174,19 @@ async fn import_primitive_u32_add_one_async(arg: u32) -> u32 {
 }
 async fn import_primitive_u64_add_one_async(arg: u64) -> u64 {
     arg + 1
+}
+
+async fn import_reset_global_state() {
+    //GLOBAL_STATE.set(0);
+    *GLOBAL_STATE.lock().unwrap() = 0;
+}
+async fn import_increment_global_state() {
+    // Possible "race condition", but we don't mind here
+    // let val = GLOBAL_STATE.get();
+    // GLOBAL_STATE.set(val + 1);
+    let mut lock = GLOBAL_STATE.lock().unwrap();
+    let value = *lock + 1;
+    *lock = value;
 }
 
 fn import_struct_with_options(arg: StructWithOptions) {

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use serde_bytes::ByteBuf;
 use std::collections::BTreeMap;
 use time::{macros::datetime, OffsetDateTime};
+use super::GLOBAL_STATE;
 
 #[cfg(not(feature="wasi"))]
 const WASM_BYTES: &'static [u8] =
@@ -18,6 +19,7 @@ const WASM_BYTES: &'static [u8] =
 #[cfg(feature="wasi")]
 const WASM_BYTES: &'static [u8] =
     include_bytes!("../../example-plugin/target/wasm32-wasi/debug/example_plugin.wasm");
+
 
 #[test]
 fn primitives() -> Result<()> {
@@ -259,6 +261,16 @@ async fn async_primitives() -> Result<()> {
     assert_eq!(rt.export_primitive_i16_add_three_async(-16).await?, -16 + 3);
     assert_eq!(rt.export_primitive_i32_add_three_async(-32).await?, -32 + 3);
     assert_eq!(rt.export_primitive_i64_add_three_async(-64).await?, -64 + 3);
+
+    // Test void primitive return as well
+    rt.export_reset_global_state().await?;
+    rt.export_increment_global_state().await?;
+    assert_eq!(*GLOBAL_STATE.lock().unwrap(), 1);
+
+    rt.export_reset_global_state().await?;
+    rt.export_increment_global_state().await?;
+    rt.export_increment_global_state().await?;
+    assert_eq!(*GLOBAL_STATE.lock().unwrap(), 2);
 
     Ok(())
 }

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -240,6 +240,30 @@ fn tagged_enums() -> Result<()> {
 }
 
 #[tokio::test]
+async fn async_primitives() -> Result<()> {
+    let rt = new_runtime()?;
+
+    assert_eq!(rt.export_primitive_bool_negate_async(true).await?, false);
+    assert_eq!(rt.export_primitive_bool_negate_async(false).await?, true);
+
+    // FIXME: Imported functions get passed 0.0 instead of the float argument when called from a plugin.
+    // See https://github.com/fiberplane/fp-bindgen/issues/180
+    // assert_eq!(rt.export_primitive_f32_add_three_async(3.5).await?, 3.5 + 3.0);
+    // assert_eq!(rt.export_primitive_f64_add_three_async(2.5).await?, 2.5 + 3.0);
+
+    assert_eq!(rt.export_primitive_u8_add_three_async(8).await?, 8 + 3);
+    assert_eq!(rt.export_primitive_u16_add_three_async(16).await?, 16 + 3);
+    assert_eq!(rt.export_primitive_u32_add_three_async(32).await?, 32 + 3);
+    assert_eq!(rt.export_primitive_u64_add_three_async(64).await?, 64 + 3);
+    assert_eq!(rt.export_primitive_i8_add_three_async(-8).await?, -8 + 3);
+    assert_eq!(rt.export_primitive_i16_add_three_async(-16).await?, -16 + 3);
+    assert_eq!(rt.export_primitive_i32_add_three_async(-32).await?, -32 + 3);
+    assert_eq!(rt.export_primitive_i64_add_three_async(-64).await?, -64 + 3);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn async_struct() -> Result<()> {
     let rt = new_runtime()?;
 

--- a/examples/example-rust-wasmer-runtime/src/test.rs
+++ b/examples/example-rust-wasmer-runtime/src/test.rs
@@ -292,7 +292,7 @@ async fn fetch_async_data() -> Result<()> {
 
     let response = rt.fetch_data("sign-up".to_string()).await?;
 
-    assert_eq!(response, Ok(r#"status: "confirmed""#.to_string()));
+    assert_eq!(response, Ok(r#"{"status":"confirmed"}"#.to_string()));
     Ok(())
 }
 

--- a/fp-bindgen/src/generators/rust_wasmer_wasi_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer_wasi_runtime/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     generators::{
         rust_plugin::generate_type_bindings,
         rust_wasmer_runtime::{
-            format_export_function, format_function_bindings, generate_import_function_variables,
+            format_function_bindings, format_import_function, generate_export_function_variables,
         },
     },
     types::TypeMap,
@@ -53,7 +53,7 @@ fn generate_create_import_object_func(import_functions: &FunctionList) -> String
     )
 }
 
-fn format_import_function(function: &Function, types: &TypeMap) -> String {
+fn format_export_function(function: &Function, types: &TypeMap) -> String {
     let (
         doc,
         modifiers,
@@ -70,7 +70,7 @@ fn format_import_function(function: &Function, types: &TypeMap) -> String {
         wasm_arg_names,
         raw_return_wrapper,
         return_wrapper,
-    ) = generate_import_function_variables(function, types);
+    ) = generate_export_function_variables(function, types);
 
     format!(
         r#"{doc}pub {modifiers}fn {name}(&self{args}) -> Result<{return_type}, InvocationError> {{
@@ -97,12 +97,12 @@ fn generate_function_bindings(
 ) {
     let imports = import_functions
         .iter()
-        .map(|function| format_export_function(function, types))
+        .map(|function| format_import_function(function, types))
         .collect::<Vec<_>>()
         .join("\n\n");
     let exports = export_functions
         .iter()
-        .map(|function| format_import_function(function, types))
+        .map(|function| format_export_function(function, types))
         .collect::<Vec<_>>()
         .join("\n\n");
     let new_func = r#"pub fn new(wasm_module: impl AsRef<[u8]>) -> Result<Self, RuntimeError> {

--- a/fp-bindgen/src/generators/ts_runtime/mod.rs
+++ b/fp-bindgen/src/generators/ts_runtime/mod.rs
@@ -312,14 +312,7 @@ fn format_raw_function_declarations(
                 .collect::<Vec<_>>()
                 .join(", ");
             let return_type = if function.is_async {
-                format!(
-                    " => Promise<{}>",
-                    function
-                        .return_type
-                        .as_ref()
-                        .map(format_raw_type)
-                        .unwrap_or("void")
-                )
+                " => Promise<Uint8Array>".to_owned()
             } else {
                 format!(
                     " => {}",
@@ -362,10 +355,14 @@ fn format_import_wrappers(import_functions: &FunctionList, types: &TypeMap) -> V
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
-            let return_type = match &function.return_type.as_ref().map(|ty| ty.as_primitive()) {
-                None => "".to_owned(),
-                Some(Some(primitive)) => format!(": {}", format_plain_primitive(*primitive)),
-                Some(_) => ": FatPtr".to_owned(),
+            let return_type = if function.is_async {
+                ": FatPtr".to_owned()
+            } else {
+                match &function.return_type.as_ref().map(|ty| ty.as_primitive()) {
+                    None => "".to_owned(),
+                    Some(Some(primitive)) => format!(": {}", format_plain_primitive(*primitive)),
+                    Some(_) => ": FatPtr".to_owned(),
+                }
             };
             let import_args = function
                 .args
@@ -390,10 +387,7 @@ fn format_import_wrappers(import_functions: &FunctionList, types: &TypeMap) -> V
                 .collect::<Vec<_>>()
                 .join(", ");
             if function.is_async {
-                let async_result = match &function.return_type {
-                    Some(_) => "serializeObject(result)",
-                    None => "0",
-                };
+                let async_result = "serializeObject(result)";
 
                 format!(
                     "__fp_gen_{}: ({}){} => {{

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -269,7 +269,12 @@ pub fn fp_export_signature(_attributes: TokenStream, input: TokenStream) -> Toke
             sig.generics.params.push(
                 syn::parse::<GenericParam>(
                     //the 'static life time is ok since we give it a box::pin
-                    (quote! {FUT: std::future::Future<Output=#output> + 'static}).into(),
+                    match output {
+                        Some(output) => {
+                            (quote! {FUT: std::future::Future<Output=#output> + 'static}).into()
+                        }
+                        None => (quote! {FUT: std::future::Future<Output=()> + 'static}).into(),
+                    },
                 )
                 .unwrap_or_abort(),
             )


### PR DESCRIPTION
The current bindgen code did not exactly expect async functions to return non-complex values. This PR updates both the wasmer runtime generation and the typescript deno runtime generation code to correctly encode async functions that return a primitive value or don't return anything, as well as adds tests in the example projects for it. Fixes [#178](https://github.com/fiberplane/fp-bindgen/issues/178).

Notable commits:
- [Update wasmer runtime generation](https://github.com/kajacx/fp-bindgen/commit/1c02dd4553a4932bac94f296637cf770ad9332db)
- [Update wasmer host generated bindings](https://github.com/kajacx/fp-bindgen/commit/78d37d95c8d5d484e130bc620c674f2c966a7925)
- [Update TS deno runtime generation](https://github.com/kajacx/fp-bindgen/commit/e710e9e0c8c4561454408f3bac4d07ccd832d7f0)
- [Update TS generated bindings](https://github.com/kajacx/fp-bindgen/commit/e20f00c3e370f8806c4d8c53dcdaae7460dc18f5)

I recommend going over these. I have also included a few minor unrelated changes, like [Unifying example response between wasmer and ts runtimes](https://github.com/kajacx/fp-bindgen/commit/ddae82825d9dd5d9c43d9515908b0c2702ce4979), which made developing easier for me, I hope that is not a problem.

One interesting choice in the examples is that the "async void" functions modify a global state (otherwise they are kind of hard to test). See [here](https://github.com/kajacx/fp-bindgen/commit/1b91ea769628932c51013510169b4be0b0364a1f). Not sure if this is the correct direction, but simply calling the exported async function and saying that "if it doesn't crash, it's fine" didn't feel right. This way, it at least tests that the imported function is called from the plugin.