### PR TITLE
Optimize `fromFatPtr()`

### DIFF
--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -1434,10 +1434,7 @@ export async function createRuntime(
 }
 
 function fromFatPtr(fatPtr: FatPtr): [ptr: number, len: number] {
-    return [
-        Number.parseInt((fatPtr >> 32n).toString()),
-        Number.parseInt((fatPtr & 0xffff_ffffn).toString()),
-    ];
+    return [Number(fatPtr >> 32n), Number(fatPtr & 0xffff_ffffn)];
 }
 
 function toFatPtr(ptr: number, len: number): FatPtr {

--- a/fp-bindgen/src/generators/ts_runtime/mod.rs
+++ b/fp-bindgen/src/generators/ts_runtime/mod.rs
@@ -197,10 +197,7 @@ export async function createRuntime(
 }}
 
 function fromFatPtr(fatPtr: FatPtr): [ptr: number, len: number] {{
-    return [
-        Number.parseInt((fatPtr >> 32n).toString()),
-        Number.parseInt((fatPtr & 0xffff_ffffn).toString()),
-    ];
+    return [Number(fatPtr >> 32n), Number(fatPtr & 0xffff_ffffn)];
 }}
 
 function toFatPtr(ptr: number, len: number): FatPtr {{


### PR DESCRIPTION
`fromFatPtr()` used to convert `BigInt` values to string before parsing them as numbers again, which really shouldn't be necessary. It's probably negligible on the whole, but a low hanging fruit anyway.