### PR TITLE
Implement streaming instantiation for TS runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.0.0-beta.2] - Unreleased
 
+### Added
+
+- Add `description`, `readme` and `license` fields to `RustPluginConfig`.
+
 ### Changed
 
-- `RustPluginConfig` now needs to be initialized using `RustPluginConfig::builder()`. Struct
-  initialization syntax will not work anymore.
-- Every field in the `RustPluginConfig` builder can be set to `RustPluginConfigValue::Workspace`
-  to indicate the value in the generated `Cargo.toml` should come from the workspace instead.
-- Add `description`, `readme` and `license` fields to `RustPluginConfig`.
-- Changed primitive tests in example to go call imported functions from the plugin.
+- `RustPluginConfig` now needs to be initialized using
+  `RustPluginConfig::builder()`. Struct initialization syntax will not work
+  anymore.
+- Every field in the `RustPluginConfig` builder can be set to
+  `RustPluginConfigValue::Workspace` to indicate the value in the generated
+  `Cargo.toml` should come from the workspace instead.
+- Changed primitive tests in example to call imported functions from the plugin.
+- The TypeScript runtime now uses streaming instantiation for the WebAssembly
+  module by default.
+- `BindingsType::TsRuntimeWithExtendedConfig` has been renamed back to
+  `BindingsType::TsRuntime` (and the old `BindingsType::TsRuntime`, which was deprecated in 2.0.0, is now removed).
 
 ### Fixed
 
-- Added workaround for imported functions with float arguments for wasmer2 in example,
-  see [#180](https://github.com/fiberplane/fp-bindgen/issues/180).
-- Fixed async functions returning primitive values, including void async functions,
-  see [#178](https://github.com/fiberplane/fp-bindgen/issues/178).
+- Added workaround for imported functions with float arguments for wasmer2 in
+  example, see [#180](https://github.com/fiberplane/fp-bindgen/issues/180).
+- Fixed async functions returning primitive values, including void async
+  functions, see [#178](https://github.com/fiberplane/fp-bindgen/issues/178).
 
 ## [3.0.0-beta.1] - 2023-02-14
 
@@ -49,10 +58,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Make sure `cargo check` doesn't complain about unused imports in the generated
   plugin bindings.
-
-### Removed
-
-- `BindingsType::TsRuntime`, which was deprecated in 2.0.0, is now removed.
 
 ## [2.4.0] - 2022-10-04
 

--- a/examples/example-deno-runtime/loader.ts
+++ b/examples/example-deno-runtime/loader.ts
@@ -4,13 +4,17 @@ import {
 } from "../example-protocol/bindings/ts-runtime/index.ts";
 
 export async function loadPlugin(path: string, imports: Imports) {
-  // This uses the Deno API to load a local file, but you might want to use
-  // `fetch()` here if you're targeting the browser.
+  // This uses the Deno API to load a plugin from a local file.
   //
-  // Example:
+  // Note that for this use case we generated the TypeScript runtime without
+  // support for streaming instantiation. This way, `createRuntime()` accepts
+  // an `ArrayBuffer` such as returned by `Deno.readFile()`.
+  //
+  // If you're targeting browsers instead, you probably want to leave streaming
+  // instantiation enabled, so that you can use it as follows:
+  //
   // ```
-  // const response = await fetch(url);
-  // const plugin = await response.arrayBuffer();
+  // const runtime = await createRuntime(fetch(url), imports);
   // ```
 
   const plugin = await Deno.readFile(path);

--- a/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
+++ b/examples/example-protocol/src/assets/ts_runtime_test/expected_index.ts
@@ -196,12 +196,12 @@ export class FPRuntimeError extends Error {
 /**
  * Creates a runtime for executing the given plugin.
  *
- * @param plugin The raw WASM plugin.
+ * @param source The response for fetching the WASM plugin.
  * @param importFunctions The host functions that may be imported by the plugin.
  * @returns The functions that may be exported by the plugin.
  */
 export async function createRuntime(
-    plugin: ArrayBuffer,
+    source: Response | Promise<Response>,
     importFunctions: Imports
 ): Promise<Exports> {
     const promises = new Map<FatPtr, ((result: FatPtr) => void) | FatPtr>();
@@ -295,7 +295,7 @@ export async function createRuntime(
         return copy;
     }
 
-    const { instance } = await WebAssembly.instantiate(plugin, {
+    const { instance } = await WebAssembly.instantiateStreaming(source, {
         fp: {
             __fp_gen_import_array_f32: (arg_ptr: FatPtr): FatPtr => {
                 const arg = parseObject<Float32Array>(arg_ptr);

--- a/examples/example-protocol/src/main.rs
+++ b/examples/example-protocol/src/main.rs
@@ -306,10 +306,11 @@ fn main() {
         ),
         BindingsType::RustWasmerRuntime,
         BindingsType::RustWasmerWasiRuntime,
-        BindingsType::TsRuntimeWithExtendedConfig(
-            TsExtendedRuntimeConfig::new()
+        BindingsType::TsRuntime(
+            TsRuntimeConfig::new()
                 .with_msgpack_module("https://unpkg.com/@msgpack/msgpack@2.7.2/mod.ts")
-                .with_raw_export_wrappers(),
+                .with_raw_export_wrappers()
+                .without_streaming_instantiation(),
         ),
     ] {
         let output_path = format!("bindings/{bindings_type}");
@@ -443,8 +444,8 @@ fn test_generate_ts_runtime() {
     ];
 
     fp_bindgen!(BindingConfig {
-        bindings_type: BindingsType::TsRuntimeWithExtendedConfig(
-            TsExtendedRuntimeConfig::new()
+        bindings_type: BindingsType::TsRuntime(
+            TsRuntimeConfig::new()
                 .with_msgpack_module("https://unpkg.com/@msgpack/msgpack@2.7.2/mod.ts")
                 .with_raw_export_wrappers()
         ),

--- a/fp-bindgen/src/generators/ts_runtime/mod.rs
+++ b/fp-bindgen/src/generators/ts_runtime/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     functions::{Function, FunctionList},
     prelude::Primitive,
     types::{CustomType, Enum, EnumOptions, Field, Struct, Type, TypeIdent, TypeMap, Variant},
-    TsExtendedRuntimeConfig,
+    TsRuntimeConfig,
 };
 use inflector::Inflector;
 use std::fs;
@@ -12,7 +12,7 @@ pub(crate) fn generate_bindings(
     import_functions: FunctionList,
     export_functions: FunctionList,
     types: TypeMap,
-    config: TsExtendedRuntimeConfig,
+    config: TsRuntimeConfig,
     path: &str,
 ) {
     generate_type_bindings(&types, path);
@@ -42,6 +42,31 @@ pub(crate) fn generate_bindings(
         Vec::new()
     };
 
+    let msgpack_module = config.msgpack_module;
+    // HACK: Import paths in TypeScript are a bit of a mess. Usually, you
+    // shouldn't need an extension, but with some configurations you do.
+    // For now, we just try to detect Deno users by looking at the
+    // `msgpack_module` and accomodate them here:
+    let import_path_extension = if msgpack_module.ends_with(".ts") {
+        ".ts"
+    } else {
+        ""
+    };
+
+    let import_lines = join_lines(&import_decls, |line| format!("    {line};"));
+    let export_lines = join_lines(&export_decls, |line| format!("    {line};"));
+    let raw_export_lines = join_lines(&raw_export_decls, |line| format!("    {line};"));
+
+    let (source_type, source_doc, streaming) = if config.streaming_instantiation {
+        (
+            "Response | Promise<Response>",
+            "The response for fetching the WASM plugin",
+            "Streaming",
+        )
+    } else {
+        ("ArrayBuffer", "The raw WASM plugin", "")
+    };
+
     let contents = format!(
         "// ============================================= //
 // WebAssembly runtime for TypeScript            //
@@ -50,17 +75,17 @@ pub(crate) fn generate_bindings(
 // ============================================= //
 // deno-lint-ignore-file no-explicit-any no-unused-vars
 
-import {{ encode, decode }} from \"{}\";
+import {{ encode, decode }} from \"{msgpack_module}\";
 
-import type * as types from \"./types{}\";
+import type * as types from \"./types{import_path_extension}\";
 
 type FatPtr = bigint;
 
 export type Imports = {{
-{}}};
+{import_lines}}};
 
 export type Exports = {{
-{}{}}};
+{export_lines}{raw_export_lines}}};
 
 /**
  * Represents an unrecoverable error in the FP runtime.
@@ -76,12 +101,12 @@ export class FPRuntimeError extends Error {{
 /**
  * Creates a runtime for executing the given plugin.
  *
- * @param plugin The raw WASM plugin.
+ * @param source {source_doc}.
  * @param importFunctions The host functions that may be imported by the plugin.
  * @returns The functions that may be exported by the plugin.
  */
 export async function createRuntime(
-    plugin: ArrayBuffer,
+    source: {source_type},
     importFunctions: Imports
 ): Promise<Exports> {{
     const promises = new Map<FatPtr, ((result: FatPtr) => void) | FatPtr>();
@@ -175,7 +200,7 @@ export async function createRuntime(
         return copy;
     }}
 
-    const {{ instance }} = await WebAssembly.instantiate(plugin, {{
+    const {{ instance }} = await WebAssembly.instantiate{streaming}(source, {{
         fp: {{
 {}        }},
     }});
@@ -207,19 +232,6 @@ function toFatPtr(ptr: number, len: number): FatPtr {{
     return (BigInt(ptr) << 32n) | BigInt(len);
 }}
 ",
-        config.msgpack_module,
-        // HACK: Import paths in TypeScript are a bit of a mess. Usually, you
-        // shouldn't need an extension, but with some configurations you do.
-        // For now, we just try to detect Deno users by looking at the
-        // `msgpack_module` and accomodate them here:
-        if config.msgpack_module.ends_with(".ts") {
-            ".ts"
-        } else {
-            ""
-        },
-        join_lines(&import_decls, |line| format!("    {line};")),
-        join_lines(&export_decls, |line| format!("    {line};")),
-        join_lines(&raw_export_decls, |line| format!("    {line};")),
         join_lines(&import_wrappers, |line| format!("            {line}")),
         if has_async_import_functions {
             "    const resolveFuture = getExport<(asyncValuePtr: FatPtr, resultPtr: FatPtr) => void>(\"__fp_guest_resolve_async_value\");\n"

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -369,5 +369,5 @@ primitive_impls!();
 #[cfg(feature = "generators")]
 pub use generators::{
     generate_bindings, BindingConfig, BindingsType, RustPluginConfig, RustPluginConfigValue,
-    TsExtendedRuntimeConfig,
+    TsRuntimeConfig,
 };

--- a/fp-bindgen/src/prelude.rs
+++ b/fp-bindgen/src/prelude.rs
@@ -4,6 +4,6 @@ pub use crate::serializable::Serializable;
 pub use crate::types::{CustomType, Type, TypeIdent, TypeMap};
 #[cfg(feature = "generators")]
 pub use crate::{
-    BindingConfig, BindingsType, RustPluginConfig, RustPluginConfigValue, TsExtendedRuntimeConfig,
+    BindingConfig, BindingsType, RustPluginConfig, RustPluginConfigValue, TsRuntimeConfig,
 };
 pub use fp_bindgen_macros::*;


### PR DESCRIPTION
MDN says the following about `WebAssembly.instantiate()`:

> This method is not the most efficient way of fetching and instantiating wasm modules. If at all possible, you should use the newer [WebAssembly.instantiateStreaming()](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiateStreaming) method instead, which fetches, compiles, and instantiates a module all in one step, directly from the raw bytecode, so doesn't require conversion to an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
- https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate

So as we're preparing to release `fp-bindgen` 3.0, we might as well make `instantiateStreaming()` the new default.