### PR TITLE
Rename xtask

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --package fp-bindgen-xtask --"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 exclude = [
   "examples/example-plugin",
   "examples/example-rust-wasmer2-runtime",
@@ -19,7 +20,7 @@ fp-bindgen-macros = { version = "3.0.0", path = "macros" }
 [workspace.package]
 version = "3.0.0"
 authors = ["Fiberplane <info@fiberplane.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/fiberplane/fp-bindgen/"
 repository = "https://github.com/fiberplane/fp-bindgen/"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # fp-bindgen
 
 [![Crates.io](https://img.shields.io/crates/v/fp-bindgen.svg)](https://crates.io/crates/fp-bindgen)
-[![Discord Shield](https://discordapp.com/api/guilds/950489382626951178/widget.png?style=shield)](https://discord.gg/fAt2xgMSGS)
+[![Discord Shield](https://discordapp.com/api/guilds/950489382626951178/widget.png?style=shield)](https://discord.gg/MJr7pYzZQ4)
 
 Bindings generator for full-stack WASM plugins.
 

--- a/fp-bindgen/src/lib.rs
+++ b/fp-bindgen/src/lib.rs
@@ -2,7 +2,7 @@
 # fp-bindgen
 
 [![Crates.io](https://img.shields.io/crates/v/fp-bindgen.svg)](https://crates.io/crates/fp-bindgen)
-[![Discord Shield](https://discordapp.com/api/guilds/950489382626951178/widget.png?style=shield)](https://discord.gg/fAt2xgMSGS)
+[![Discord Shield](https://discordapp.com/api/guilds/950489382626951178/widget.png?style=shield)](https://discord.gg/MJr7pYzZQ4)
 
 Bindings generator for full-stack WASM plugins.
 

--- a/macros/src/primitives.rs
+++ b/macros/src/primitives.rs
@@ -88,7 +88,7 @@ impl ToTokens for Primitive {
             U64 => "U64",
         };
         let ident = Ident::new(ident_str, Span::call_site());
-        tokens.extend(vec![TokenTree::Ident(ident)].into_iter());
+        tokens.extend(vec![TokenTree::Ident(ident)]);
     }
 }
 

--- a/macros/src/serializable.rs
+++ b/macros/src/serializable.rs
@@ -111,7 +111,7 @@ pub(crate) fn impl_derive_serializable(item: TokenStream) -> TokenStream {
         });
         quote! {
             where
-                #( #params#param_bounds ),*
+                #( #params #param_bounds ),*
         }
     };
 
@@ -131,7 +131,7 @@ pub(crate) fn impl_derive_serializable(item: TokenStream) -> TokenStream {
     };
 
     let implementation = quote! {
-        impl#generics fp_bindgen::prelude::Serializable for #item_name#generics#where_clause {
+        impl #generics fp_bindgen::prelude::Serializable for #item_name #generics #where_clause {
             fn ident() -> fp_bindgen::prelude::TypeIdent {
                 #ident
             }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xtask"
+name = "fp-bindgen-xtask"
 version = "0.1.0"
 edition = "2021"
 

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -20,7 +20,7 @@ pub fn cargo(args: impl IntoIterator<Item = impl Into<OsString>>) -> Expression 
 
 pub fn deno(args: impl IntoIterator<Item = impl Into<OsString>>) -> Expression {
     let args: VecDeque<OsString> = args.into_iter().map(|os| os.into()).collect();
-    cmd("deno", &args)
+    cmd("deno", args)
 }
 
 pub fn from_root(path: impl Into<PathBuf>) -> PathBuf {


### PR DESCRIPTION
This is a minor change that allows the `xtask` crate from this repo to co-exist with the crates from our other repos when combined using Git submodules.

Also bumped the Rust edition to 2021, since that's what we use in monofiber.