### PR TITLE
Bump `pretty_assertions` dependency

### DIFF
--- a/examples/example-protocol/Cargo.toml
+++ b/examples/example-protocol/Cargo.toml
@@ -5,18 +5,18 @@ name = "example-protocol"
 version = "0.1.0"
 
 [dependencies]
-bytes = {version = "1", features = ["serde"]}
-fp-bindgen = {path = "../../fp-bindgen", features = [
+bytes = { version = "1", features = ["serde"] }
+fp-bindgen = { path = "../../fp-bindgen", features = [
   "bytes-compat",
   "http-compat",
   "serde-bytes-compat",
   "time-compat",
   "generators",
-]}
+] }
 http = "0.2"
 once_cell = "1"
-pretty_assertions = "0.7"
-redux-example = {path = "../redux-example"}
-serde = {version = "1.0", features = ["derive"]}
+pretty_assertions = "1"
+redux-example = { path = "../redux-example" }
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-time = {version = "0.3", features = ["macros", "serde-human-readable"]}
+time = { version = "0.3", features = ["macros", "serde-human-readable"] }


### PR DESCRIPTION
Tiny fix to no longer use an outdated version of `pretty_assertions` which depended on unmaintained crates (`ansi_term`).

Fixes https://github.com/fiberplane/monofiber/issues/90