### PR TITLE
Fix Clippies about `partial_cmp()`

### DIFF
--- a/fp-bindgen/src/functions.rs
+++ b/fp-bindgen/src/functions.rs
@@ -97,7 +97,7 @@ impl Ord for Function {
 
 impl PartialOrd for Function {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.name.partial_cmp(&other.name)
+        Some(self.cmp(other))
     }
 }
 

--- a/fp-bindgen/src/types/type_ident.rs
+++ b/fp-bindgen/src/types/type_ident.rs
@@ -170,10 +170,7 @@ impl Ord for TypeIdent {
 
 impl PartialOrd for TypeIdent {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        // We only compare the name and array so that any type is only included once in
-        // a map, regardless of how many concrete instances are used with
-        // different generic arguments.
-        (&self.name, self.array).partial_cmp(&(&other.name, other.array))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
Looks like newer Clippy versions are more strict about the implementation of `PartialOrd`. If the type also implements `Ord`, `partial_cmp()` must defer to `cmp()` to guarantee consistent behavior.