### PR TITLE
Explicitly specify crate versions

### DIFF
--- a/fp-bindgen-support/Cargo.toml
+++ b/fp-bindgen-support/Cargo.toml
@@ -4,7 +4,7 @@ description = "Support crate for fp-bindgen"
 homepage = { workspace = true }
 repository = { workspace = true }
 readme = "README.md"
-version = { workspace = true }
+version = "3.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fp-bindgen/Cargo.toml
+++ b/fp-bindgen/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 readme = "../README.md"
 keywords = ["WebAssembly", "WASM", "bindgen"]
 categories = ["development-tools::ffi", "wasm"]
-version = { workspace = true }
+version = "3.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -22,7 +22,7 @@ default = [
     "rmpv-compat",
     "serde-bytes-compat",
     "serde-json-compat",
-    "time-compat"
+    "time-compat",
 ]
 http-compat = ["http"]
 rmpv-compat = ["rmpv"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Macros for fp-bindgen"
 homepage = { workspace = true }
 repository = { workspace = true }
 readme = "README.md"
-version = { workspace = true }
+version = "3.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
This will make sure the versions are defined currently when included from our `monofiber` setup.