### PR TITLE
Fix Clippies

### DIFF
--- a/examples/example-protocol/src/assets/rust_wasmer2_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer2_runtime_test/expected_bindings.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(clippy::let_and_return, unused)]
 use super::types::*;
 use fp_bindgen_support::{
     common::{abi::WasmAbi, mem::FatPtr},

--- a/examples/example-protocol/src/assets/rust_wasmer2_wasi_runtime_test/expected_bindings.rs
+++ b/examples/example-protocol/src/assets/rust_wasmer2_wasi_runtime_test/expected_bindings.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(clippy::let_and_return, unused)]
 use super::types::*;
 use fp_bindgen_support::{
     common::{abi::WasmAbi, mem::FatPtr},

--- a/fp-bindgen/src/generators/rust_wasmer2_runtime/mod.rs
+++ b/fp-bindgen/src/generators/rust_wasmer2_runtime/mod.rs
@@ -339,7 +339,7 @@ pub(crate) fn format_function_bindings(
     new_func: String,
     create_import_object_func: String,
 ) -> String {
-    rustfmt_wrapper::rustfmt(format!(r#"#![allow(unused)]
+    rustfmt_wrapper::rustfmt(format!(r#"#![allow(clippy::let_and_return, unused)]
 use super::types::*;
 use fp_bindgen_support::{{
     common::{{mem::FatPtr, abi::WasmAbi}},


### PR DESCRIPTION
This adds an exception to the generated Rust bindings so that they don't trigger a bunch of Clippy warnings.