### PR TITLE
Generate value as bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## unreleased
 
 - Add ability to add `publish` to the generated Cargo.toml file (#208)
+- Fix generating publish value as a toml bool (#209)
 
 ## [3.0.0] - 2023-04-28
 

--- a/fp-bindgen/src/generators/mod.rs
+++ b/fp-bindgen/src/generators/mod.rs
@@ -97,6 +97,7 @@ pub enum RustPluginConfigValue {
     String(String),
     Vec(Vec<String>),
     Workspace,
+    Bool(bool),
 }
 
 impl From<&str> for RustPluginConfigValue {
@@ -120,6 +121,12 @@ impl From<Vec<&str>> for RustPluginConfigValue {
 impl From<Vec<String>> for RustPluginConfigValue {
     fn from(value: Vec<String>) -> Self {
         Self::Vec(value)
+    }
+}
+
+impl From<bool> for RustPluginConfigValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
     }
 }
 
@@ -184,7 +191,7 @@ impl RustPluginConfigBuilder {
     }
 
     pub fn publish(mut self, value: bool) -> Self {
-        self.config.publish = Some(RustPluginConfigValue::String(value.to_string()));
+        self.config.publish = Some(value.into());
         self
     }
 

--- a/fp-bindgen/src/generators/rust_plugin/mod.rs
+++ b/fp-bindgen/src/generators/rust_plugin/mod.rs
@@ -592,6 +592,7 @@ fn format_cargo_key(key: &str, value: Option<RustPluginConfigValue>) -> String {
                 inline.insert("workspace", true.into());
                 toml_edit::value(inline)
             }
+            RustPluginConfigValue::Bool(value) => toml_edit::value(value),
         };
 
         let mut doc = toml_edit::Document::new();


### PR DESCRIPTION
This will generate publish=false as an actual toml bool, instead of a string value
